### PR TITLE
- Removing ${project.version} from SIP dependencies

### DIFF
--- a/changelogs/bugfix/adapter-and-framework-version-split.json
+++ b/changelogs/bugfix/adapter-and-framework-version-split.json
@@ -1,0 +1,5 @@
+{
+  "author": "vladiikor",
+  "pullrequestId": 6,
+  "message": "Replacing ${project.version} in SIP dependencies with ${sip-framework.version}. Versioning will be handled trough release pipeline."
+}

--- a/pom.xml
+++ b/pom.xml
@@ -99,8 +99,10 @@
         <!-- instead of aggregating coverage we reference all single coverage files for the projects
              this forces the unit-tests for specific tools to be part of the submodule, instead of
              beeing anywhere -->
-        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml
+        </sonar.coverage.jacoco.xmlReportPaths>
         <sonar.coverage.exclusions>**/*Config*</sonar.coverage.exclusions>
+        <sip-framework.version>1.0.0-SNAPSHOT</sip-framework.version>
     </properties>
 
     <modules>
@@ -112,7 +114,7 @@
         <module>sip-archetype</module>
     </modules>
 
-   <dependencyManagement>
+    <dependencyManagement>
         <dependencies>
             <!-- spring dependencies -->
             <dependency>
@@ -160,22 +162,22 @@
             <dependency>
                 <groupId>de.ikor.sip.foundation</groupId>
                 <artifactId>sip-integration-starter</artifactId>
-                <version>${project.version}</version>
+                <version>${sip-framework.version}</version>
             </dependency>
             <dependency>
                 <groupId>de.ikor.sip.foundation</groupId>
                 <artifactId>sip-core</artifactId>
-                <version>${project.version}</version>
+                <version>${sip-framework.version}</version>
             </dependency>
             <dependency>
                 <groupId>de.ikor.sip.foundation</groupId>
                 <artifactId>sip-middle-component</artifactId>
-                <version>${project.version}</version>
+                <version>${sip-framework.version}</version>
             </dependency>
             <dependency>
                 <groupId>de.ikor.sip.foundation</groupId>
                 <artifactId>sip-security</artifactId>
-                <version>${project.version}</version>
+                <version>${sip-framework.version}</version>
             </dependency>
 
             <!-- camel -->

--- a/sip-starter-parent/pom.xml
+++ b/sip-starter-parent/pom.xml
@@ -17,10 +17,11 @@
     <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>SIP Starter Parent</name>
-    <description>Parent pom providing dependency and plugin management for SIP integration adapters built with Maven</description>
+    <description>Parent pom providing dependency and plugin management for SIP integration adapters built with Maven
+    </description>
 
     <properties>
-        <sip-dependency.version>1.0.0-SNAPSHOT</sip-dependency.version>
+        <sip-framework.version>1.0.0-SNAPSHOT</sip-framework.version>
     </properties>
 
     <dependencies>
@@ -37,7 +38,7 @@
             <dependency>
                 <groupId>de.ikor.sip.foundation</groupId>
                 <artifactId>sip-framework</artifactId>
-                <version>${sip-dependency.version}</version>
+                <version>${sip-framework.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
# Description

Splitting SIP framework dependencies versions from adapter project.version variable. Custom sip-framework.version variable is used and all parent versions are hard-coded.

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- Run mvn clean install on sip-framework root.
- Make sure that sip-framework version on adapter corresponds to version under test. 
- Run mvn clean -X on adapter. 
- Expected result: Log contains no complains about sip-framework version

**Test Configuration**:
* SIP Framework version(s):
* Other configuration:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing (regression) unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
