### PR TITLE
Fixing problem with missing headers in adapter readme file.

### DIFF
--- a/changelogs/documentation/fixing_adapter_readme_headers.json
+++ b/changelogs/documentation/fixing_adapter_readme_headers.json
@@ -1,0 +1,5 @@
+{
+  "author": "nikolag-ikor",
+  "pullrequestId": "12",
+  "message": "Fixed missing headers in adapter readme file."
+}

--- a/sip-archetype/src/main/resources/archetype-resources/README.md
+++ b/sip-archetype/src/main/resources/archetype-resources/README.md
@@ -1,6 +1,6 @@
-## Welcome!
+# Welcome!
 
-### Thank you for using SIP Framework!
+**Thank you for using SIP Framework!**
 
 You have successfully created ${artifactId}. We recommend you to describe the adapter you are developing within this file.
 


### PR DESCRIPTION
# Description

This PR fixes missing headers in adapter readme file.

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

- mvn clean
- mvn install -> archetype SNAPSHOT version will be created in your local maven repository .m2
- mvn archetype:generate \
    -DarchetypeGroupId=de.ikor.sip.foundation \
    -DarchetypeArtifactId=sip-archetype \
    -DarchetypeVersion=1.0.0 \
    -DgroupId=de.ikor.sip.adapter \
    -DartifactId=demo \
    -DprojectName=DemoAdapter \
    -Dversion=1.0.0-SNAPSHOT
Use your SNAPSHOT version for  DarchetypeVersion parameter.
- check in your generated adapter README file if headers "Welcome" and "Thank you for using SIP Framework!" are present.

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing (regression) unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
