### PR TITLE
set placeholder for archetype version in docs

### DIFF
--- a/changelogs/documentation/updated-archetype-script.json
+++ b/changelogs/documentation/updated-archetype-script.json
@@ -1,0 +1,5 @@
+{
+  "author": "dzuci",
+  "pullrequestId": 16,
+  "message": "Set placeholder for archetype version in docs"
+}

--- a/docs/archetype.md
+++ b/docs/archetype.md
@@ -16,7 +16,7 @@ To make a long story short, you can create a SIP Adapter by using the following 
   mvn archetype:generate \
     -DarchetypeGroupId=de.ikor.sip.foundation \
     -DarchetypeArtifactId=sip-archetype \
-    -DarchetypeVersion=1.0.0 \
+    -DarchetypeVersion=<latest.sip-archetype.version> \
     -DgroupId=de.ikor.sip.adapter \
     -DartifactId=demo \
     -DprojectName=DemoAdapter \

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,7 +40,7 @@ Creating an application using SIP archetype on the command line:
   mvn archetype:generate \
     -DarchetypeGroupId=de.ikor.sip.foundation \
     -DarchetypeArtifactId=sip-archetype \
-    -DarchetypeVersion=1.0.0 \
+    -DarchetypeVersion=<latest.sip-archetype.version> \
     -DgroupId=de.ikor.sip.adapter \
     -DartifactId=demo \
     -DprojectName=DemoAdapter \


### PR DESCRIPTION
# Description

Set a placeholder for the archetype version in documentation (changed to <latest.sip-archetype.version>)

## Type of change

Please delete options that are not relevant.
- [x] This change requires a documentation update

# How Has This Been Tested?

Check "archetype.md" and "installation.md".

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing (regression) unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
