### PR TITLE
SIP-796 Added archetype parameter which provides a choice for optiona…

### DIFF
--- a/changelogs/feature/optional_lombok_parameter.json
+++ b/changelogs/feature/optional_lombok_parameter.json
@@ -1,0 +1,5 @@
+{
+  "author": "nikolag-ikor",
+  "pullrequestId": "17",
+  "message": "Added archetype parameter which provides a choice for optional including/excluding of Lombok dependency."
+}

--- a/docs/archetype.md
+++ b/docs/archetype.md
@@ -38,6 +38,9 @@ After executing maven command, you will be requested to insert additional parame
 - **systemConnector1**/**systemConnector2** are representing names of your connector modules inside the project. Naming recommendation is to use lower case letters and kebab-case.
 - **systemConnector1Package**/**systemConnector2Package** are used to define package name suffix for the connectors. Notice that
   connector package name starts with prefix defined on **package** step.
+- **useLombokDefault**/**useLombok** are properties used for including or excluding Lombok dependency in adapter.
+  Parameter useLombokDefault is only used to include lombok by default. If you wish to exclude lombok you should set 
+  useLombok to anything other than 'y' or 'Y'.
 
 After a successful build, a project with the 4 following modules will be created:
 

--- a/docs/archetype.md
+++ b/docs/archetype.md
@@ -38,6 +38,8 @@ After executing maven command, you will be requested to insert additional parame
 - **systemConnector1**/**systemConnector2** are representing names of your connector modules inside the project. Naming recommendation is to use lower case letters and kebab-case.
 - **systemConnector1Package**/**systemConnector2Package** are used to define package name suffix for the connectors. Notice that
   connector package name starts with prefix defined on **package** step.
+- **useLombok** is property used for including or excluding Lombok dependency in adapter. Possible values: 'y' - include Lombok,
+  'n' - exclude Lombok.
 
 After a successful build, a project with the 4 following modules will be created:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -67,6 +67,9 @@ After executing maven command, you will be requested to insert additional parame
 - **systemConnector1Package**/**systemConnector2Package** are used to define package name suffix for the connectors. Notice that
   connector package name starts with prefix defined on **package** step.
 
+- **useLombok** is property used for including or excluding Lombok dependency in adapter. Possible values: 'y' - include Lombok,
+  'n' - exclude Lombok.
+
 After a successful build, a project with the 4 following modules will be created:
 
 - {artifactId}-application

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -67,6 +67,10 @@ After executing maven command, you will be requested to insert additional parame
 - **systemConnector1Package**/**systemConnector2Package** are used to define package name suffix for the connectors. Notice that
   connector package name starts with prefix defined on **package** step.
 
+- **useLombokDefault**/**useLombok** are properties used for including or excluding Lombok dependency in adapter.
+  Parameter useLombokDefault is only used to include lombok by default. If you wish to exclude lombok you should set
+  useLombok to anything other than 'y' or 'Y'.
+
 After a successful build, a project with the 4 following modules will be created:
 
 - {artifactId}-application

--- a/sip-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/sip-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -51,6 +51,12 @@ under the License.
             <validationRegex>^(?!.*([._%+-])\1)[a-z0-9\._]+$
             </validationRegex>
         </requiredProperty>
+        <requiredProperty key="useLombokDefault">
+            <defaultValue>y</defaultValue>
+        </requiredProperty>
+        <requiredProperty key="useLombok">
+            <defaultValue>${useLombokDefault}</defaultValue>
+        </requiredProperty>
         <requiredProperty key="archetypeVersion"> </requiredProperty>
     </requiredProperties>
 

--- a/sip-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/sip-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -51,6 +51,10 @@ under the License.
             <validationRegex>^(?!.*([._%+-])\1)[a-z0-9\._]+$
             </validationRegex>
         </requiredProperty>
+        <requiredProperty key="useLombok">
+            <validationRegex>y|n
+            </validationRegex>
+        </requiredProperty>
         <requiredProperty key="archetypeVersion"> </requiredProperty>
     </requiredProperties>
 

--- a/sip-archetype/src/main/resources/archetype-resources/__rootArtifactId__-domain/pom.xml
+++ b/sip-archetype/src/main/resources/archetype-resources/__rootArtifactId__-domain/pom.xml
@@ -13,10 +13,12 @@
     <name>${artifactId}</name>
 
     <dependencies>
+#if (${useLombok} == "y")
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
         </dependency>
+#end
     </dependencies>
 </project>

--- a/sip-archetype/src/main/resources/archetype-resources/__rootArtifactId__-domain/pom.xml
+++ b/sip-archetype/src/main/resources/archetype-resources/__rootArtifactId__-domain/pom.xml
@@ -11,12 +11,5 @@
 
     <artifactId>${artifactId}</artifactId>
     <name>${artifactId}</name>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
+    
 </project>

--- a/sip-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/sip-archetype/src/main/resources/archetype-resources/pom.xml
@@ -24,10 +24,12 @@
     </modules>
 
     <dependencies>
+#if (${useLombok} == "y")
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+#end
     </dependencies>
 
     <dependencyManagement>

--- a/sip-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/sip-archetype/src/main/resources/archetype-resources/pom.xml
@@ -24,10 +24,12 @@
     </modules>
 
     <dependencies>
+#if (${useLombok} == "y" || ${useLombok} == "Y")
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+#end
     </dependencies>
 
     <dependencyManagement>


### PR DESCRIPTION
…l including/excluding of Lombok dependency.

# Description

Adding new cmd dialog input parameter so user could be able to choose if he want Lombok dependency within generated adapter.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Run following commands:
mvn clean
mvn install

After running commands above, SNAPSHOT archetype version will be created in your local maven repository (.m2 directory).
Execute maven command for generating the adapter. Use your local archetype version within command.
Follow the cmd dialog and notice 2 new parameters **useLombokDefault** and **useLombok**. **useLombokDefault** represents default value of a **useLombok** and that value is 'y', which means Lombok should be included.
After showing info **useLombokDefault** in promt, user is asked to enter **useLombok**, he can just skip it and keep the default value (the same behavior is happening if typing 'y' or 'Y') or remove Lombok by typing anything else.
Test if  cmd dialog behaviour is ok.
When adapter is created, test if Lombok dependency exist/doesn't exist.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing (regression) unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
