### PR TITLE
Bug/sip 812 client auth not working

### DIFF
--- a/changelogs/bugfix/client-auth-config.yml
+++ b/changelogs/bugfix/client-auth-config.yml
@@ -1,0 +1,5 @@
+{
+  "author": "vladiIkor",
+  "pullrequestId": 19,
+  "message": "Adding sip.security.ssl.server.client-auth config key to sip-security"
+}

--- a/docs/security.md
+++ b/docs/security.md
@@ -27,8 +27,8 @@ Implementing code and configuration on top of Spring Security should help you ju
 Following description shows SIP Security functionalities and configuration.
 
 #### SSL
-SSL is by default turned off. It can be activated by setting a server side certificate or turning the client SSL explicitly on and optionally setting a client certificate.
-If no server certificate is set a client certificate is mandatory when turning on client SSL.
+SSL is by default turned off. It can be activated by setting a server side certificate or turning the client SSL explicitly 
+on and optionally setting a client certificate. If no server certificate is set a client certificate is mandatory when turning on client SSL.
 
 - Client (our application is consuming APIs using the provided certificate)
   ```yaml
@@ -50,8 +50,9 @@ If no server certificate is set a client certificate is mandatory when turning o
               enabled: false
   ```
   The truststore is handled with Java default:
-    - set the cacerts in the runtime accordingly (preferrable approach)
-    - for local development you could add any certificate, IntermediateCA, RootCA or complete certificate chain to the keystore as a trusted certificate (e.g. by importing it with tools like keytool), a possible command could be:
+    - set the cacerts in the runtime accordingly (preferable approach)
+    - for local development you could add any certificate, IntermediateCA, RootCA or complete certificate chain to the 
+      keystore as a trusted certificate (e.g. by importing it with tools like keytool), a possible command could be:
   `keytool -importcert -file certificate.cer -keystore keystore.jks -alias "Alias"`
 
 - Server (our application is providing APIs using the provided certificate)
@@ -64,6 +65,8 @@ If no server certificate is set a client certificate is mandatory when turning o
               key-store-type: pkcs12 #possible options are pkcs12, jks, jceks
               key-alias: springboot #the alias of the key to be chosen from the container
               key-password: password # we recommend to use env_vars or sealed secrets
+              client-auth: want # Could be: need (client auth is mandatory), want (client auth is is wanted but not 
+              # mandatory) and none (default)
   ```
   To turn the usage of the server certificate off:
   ```yaml
@@ -89,7 +92,7 @@ sip.security:
 
 - <u>Extractors</u> (extract the relevant token from an http-requests)
     - BasicAuth: Extracts the BasicAuth credentials from the request
-    - X509: Extracts the X509 certificate from the request
+    - X509: Extracts the X509 certificate from the request (requires sip.security.ssl.server.client-auth set to need or want)
 - <u>Providers</u> (triggers a Validator to validate a given authentication)
     - BasicAuth: Takes the extracted basic auth token and uses the given validator from the configuration to validate the token
     - X509: Takes the extracted X509 token and uses the given validator from the configuration to validate the token

--- a/sip-security/src/main/resources/sip-security-default-config.yaml
+++ b/sip-security/src/main/resources/sip-security-default-config.yaml
@@ -30,6 +30,7 @@ sip.security:
   ssl:
     # These settings have to be set by the application, by default ssl is disabled
     server:
+      client-auth: none
       key-store:
       key-store-password:
       key-store-type:

--- a/sip-security/src/main/resources/sip-security-default-config.yaml
+++ b/sip-security/src/main/resources/sip-security-default-config.yaml
@@ -6,6 +6,7 @@
 
 server:
   ssl:
+    client-auth: ${sip.security.ssl.server.client-auth}
     key-store: ${sip.security.ssl.server.key-store}
     key-store-password: ${sip.security.ssl.server.key-store-password}
     key-store-type: ${sip.security.ssl.server.key-store-type}
@@ -24,7 +25,6 @@ camel:
       resource: ${sip.security.ssl.client.key-store}
       password: ${sip.security.ssl.client.key-store-password}
       type: ${sip.security.ssl.client.key-store-type}
-  http.use-global-ssl-context-parameters: true # try without this, it should work
 
 sip.security:
   ssl:


### PR DESCRIPTION
# Description
sip.security.ssl.server.client-auth configuration is added into sip-security module with default value none. In order for
SIPX509AuthenticationProvider to work properly, this value must be set to want or need. 
Until the next release version alternative config can be used:
server.ssl.client-auth: 

Fixes #50 

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- Make sure you have java (or system) trust store set up locally 
- Set up Postman with client certificates that are trusted by trust store
- Set up SIP adapter with sip-security module (security config and dependency below)
- Try to access /actuator/health

**Test Configuration**:
```
sip:
  security:
    authentication:
      enabled: true  #turn on/off all authentication functionality
      auth-providers:
        - classname: de.ikor.sip.foundation.security.authentication.x509.SIPX509AuthenticationProvider
          ignored-endpoints: #a list of endpoints which are ignored by this specific authenticator
            - /favicon.ico
            - /actuator/env
            - /actuator
          validation:
            classname: de.ikor.sip.foundation.security.authentication.x509.SIPX509FileValidator #FQCN o´f the validator to be used
            file-path: classpath:client-certs.acl  # possible resource strings are classpath:, file:, http:, _none_
    ssl:
      client:
        enabled: true

      server:
        key-store: C:/ssl/keystore.jks # possible resource strings are classpath:, file:, http:, _none_
        key-store-password: changeit # we recommend to use env_vars or sealed secrets
        key-store-type: jks #possible options are pkcs12, jks, jceks
        key-alias: localhost #the alias of the key to be chosen from the container
        key-password: changeit # we recommend to use env_vars or sealed secrets
        client-auth: want
```

```
 <dependency>
            <groupId>de.ikor.sip.foundation</groupId>
            <artifactId>sip-security</artifactId>
</dependency>
```


* SIP Framework version(s): 1.0.1-SNAPSHOT
* Other configuration:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing (regression) unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
