### PR TITLE
- Excluding Spring security auto-config classes to prevent default authentication

### DIFF
--- a/changelogs/bugfix/disable-default-spring-auth.yml
+++ b/changelogs/bugfix/disable-default-spring-auth.yml
@@ -1,5 +1,5 @@
 {
   "author": "vladiIkor",
-  "pullrequestId": ,
+  "pullrequestId": 20,
   "message": "Excluding Spring security auto-config classes to prevent default authentication"
 }

--- a/changelogs/bugfix/disable-default-spring-auth.yml
+++ b/changelogs/bugfix/disable-default-spring-auth.yml
@@ -1,0 +1,5 @@
+{
+  "author": "vladiIkor",
+  "pullrequestId": ,
+  "message": "Excluding Spring security auto-config classes to prevent default authentication"
+}

--- a/sip-security/src/main/resources/sip-security-default-config.yaml
+++ b/sip-security/src/main/resources/sip-security-default-config.yaml
@@ -45,3 +45,9 @@ sip.security:
       key-store-type: ${sip.security.ssl.server.key-store-type}
       key-alias: ${sip.security.ssl.server.key-alias}
       key-password: ${sip.security.ssl.server.key-password}
+
+# Disabling Springs security autoconfiguration which applies base auth by default if no other authentication is provided.
+spring:
+  autoconfigure:
+    exclude[0]: org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+    exclude[1]: org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration


### PR DESCRIPTION
# Description

In case of no custom authentication is detected on classpath, Spring auto-configures its own base authenticator. This behavior is unwanted and prevented from now on. Setting:
```
sip:
  security:
    authentication:
      enabled: false
```
Should and will result in no additional authentication applied.

Fixes #47 

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Make sure you have java (or system) trust store set up locally 
- Set sip.security.authentication.enabled: false in adapter config
- Setup Postmen with proper certificate
- Start the SIP adapter and try to access /actuator endpoint

**Test Configuration**:
```
sip:
  security:
    authentication:
      enabled: false  #turn on/off all authentication functionality
    ssl:
      client:
        enabled: true
      server:
        key-store: C:/ssl/keystore.jks # possible resource strings are classpath:, file:, http:, _none_
        key-store-password: changeit # we recommend to use env_vars or sealed secrets
        key-store-type: jks #possible options are pkcs12, jks, jceks
        key-alias: localhost #the alias of the key to be chosen from the container
        key-password: changeit # we recommend to use env_vars or sealed secrets
```
* SIP Framework version(s): 1.0.1-SNAPSHOT

# Checklist:
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing (regression) unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
