### PR TITLE
Remove authentication enabled flag

### DIFF
--- a/changelogs/feature/remove_auth_enabled_flag.json
+++ b/changelogs/feature/remove_auth_enabled_flag.json
@@ -1,0 +1,5 @@
+{
+  "author": "Nemikor",
+  "pullrequestId": "30",
+  "message": "Removed sip.security.authentication.enabled flag, now only authentication provider list is necessary."
+}

--- a/docs/security.md
+++ b/docs/security.md
@@ -82,7 +82,6 @@ Global authentication configuration:
 ```yaml
 sip.security:
     authentication:
-        enabled: true #turn on/off all authentication functionality
         disable-csrf: true
         ignored-endpoints: #a list of endpoints which are ignored by ALL authenticators based on Spring´s AntPathMatchers implementation
         - /actuator
@@ -101,8 +100,7 @@ sip.security:
       ```yaml
       sip.security:
           authentication:
-              enabled: true #turn on/off all authentication functionality
-              auth-providers:
+              auth-providers: #authentication functionality is enabled if valid providers are defined
                   - classname: de.ikor.sip.foundation.security.authentication.basic.SIPBasicAuthAuthenticationProvider
                     ignored-endpoints: #a list of endpoints which are ignored by this specific authenticator based on Spring´s AntPathMatchers implementation
                       - /actuator/health
@@ -122,8 +120,7 @@ sip.security:
     ```yaml
     sip.security:
         authentication:
-            enabled: true  #turn on/off all authentication functionality
-            auth-providers:
+            auth-providers: #authentication functionality is enabled if valid providers are defined
                 - classname: de.ikor.sip.foundation.security.authentication.x509.SIPX509AuthenticationProvider
                   ignored-endpoints: #a list of endpoints which are ignored by this specific authenticator based on Spring´s AntPathMatchers implementation
                     - /favicon.ico

--- a/sip-security/src/main/java/de/ikor/sip/foundation/security/authentication/SIPAuthProviderCondition.java
+++ b/sip-security/src/main/java/de/ikor/sip/foundation/security/authentication/SIPAuthProviderCondition.java
@@ -27,7 +27,7 @@ public class SIPAuthProviderCondition extends SpringBootCondition {
         metadata.getAllAnnotationAttributes(ConditionalOnSIPAuthProvider.class.getName());
 
     Collection<AuthProviderSettings> authSettings =
-        AuthProviderSettings.getAuthProviderSettingsList(context);
+        AuthProviderSettings.bindFromPropertySource(context.getEnvironment());
 
     if (isNotEmpty(authSettings)) {
       Class<?> listItemValue = (Class<?>) attributes.get("listItemValue").get(0);
@@ -43,7 +43,7 @@ public class SIPAuthProviderCondition extends SpringBootCondition {
           return ConditionOutcome.noMatch(
               ConditionMessage.forCondition("SIP validation type check")
                   .didNotFind("property")
-                  .items(AuthProviderSettings.getListPropertyName()));
+                  .items(AuthProviderSettings.getConfigurationPropertyName()));
         }
         return ConditionOutcome.match();
       }
@@ -52,6 +52,6 @@ public class SIPAuthProviderCondition extends SpringBootCondition {
     return ConditionOutcome.noMatch(
         ConditionMessage.forCondition("SIP list location")
             .didNotFind("property")
-            .items(AuthProviderSettings.getListPropertyName()));
+            .items(AuthProviderSettings.getConfigurationPropertyName()));
   }
 }

--- a/sip-security/src/main/java/de/ikor/sip/foundation/security/authentication/SIPAuthProviderCondition.java
+++ b/sip-security/src/main/java/de/ikor/sip/foundation/security/authentication/SIPAuthProviderCondition.java
@@ -43,7 +43,7 @@ public class SIPAuthProviderCondition extends SpringBootCondition {
           return ConditionOutcome.noMatch(
               ConditionMessage.forCondition("SIP validation type check")
                   .didNotFind("property")
-                  .items(AuthProviderSettings.getConfigurationPropertyName()));
+                  .items(AuthProviderSettings.AUTH_PROVIDERS_PROPERTY_NAME));
         }
         return ConditionOutcome.match();
       }
@@ -52,6 +52,6 @@ public class SIPAuthProviderCondition extends SpringBootCondition {
     return ConditionOutcome.noMatch(
         ConditionMessage.forCondition("SIP list location")
             .didNotFind("property")
-            .items(AuthProviderSettings.getConfigurationPropertyName()));
+            .items(AuthProviderSettings.AUTH_PROVIDERS_PROPERTY_NAME));
   }
 }

--- a/sip-security/src/main/java/de/ikor/sip/foundation/security/authentication/SIPAuthProvidersExistCondition.java
+++ b/sip-security/src/main/java/de/ikor/sip/foundation/security/authentication/SIPAuthProvidersExistCondition.java
@@ -1,0 +1,38 @@
+package de.ikor.sip.foundation.security.authentication;
+
+import de.ikor.sip.foundation.security.config.SecurityConfigProperties.AuthProviderSettings;
+import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionMessage;
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.boot.context.properties.bind.BindResult;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/** Condition class matching whether authentication providers are defined */
+public class SIPAuthProvidersExistCondition extends SpringBootCondition {
+  private static final Bindable<List<AuthProviderSettings>> PROVIDER_LIST =
+      Bindable.listOf(AuthProviderSettings.class);
+
+  @Override
+  public ConditionOutcome getMatchOutcome(
+      ConditionContext context, AnnotatedTypeMetadata metadata) {
+
+    String listProperty = "sip.security.authentication.auth-providers";
+
+    BindResult<List<AuthProviderSettings>> property =
+        Binder.get(context.getEnvironment()).bind(listProperty, PROVIDER_LIST);
+    List<AuthProviderSettings> authSettings = property.orElse(null);
+
+    if (authSettings != null && !authSettings.isEmpty()) {
+      return ConditionOutcome.match();
+    }
+
+    return ConditionOutcome.noMatch(
+        ConditionMessage.forCondition("SIP auth provider condition")
+            .didNotFind("property")
+            .items(listProperty));
+  }
+}

--- a/sip-security/src/main/java/de/ikor/sip/foundation/security/authentication/SIPAuthProvidersExistCondition.java
+++ b/sip-security/src/main/java/de/ikor/sip/foundation/security/authentication/SIPAuthProvidersExistCondition.java
@@ -22,7 +22,7 @@ public class SIPAuthProvidersExistCondition extends SpringBootCondition {
           ConditionOutcome.noMatch(
               ConditionMessage.forCondition("SIP auth providers condition")
                   .didNotFind("property")
-                  .items(AuthProviderSettings.getConfigurationPropertyName()));
+                  .items(AuthProviderSettings.AUTH_PROVIDERS_PROPERTY_NAME));
     }
     return outcome;
   }

--- a/sip-security/src/main/java/de/ikor/sip/foundation/security/authentication/SIPAuthProvidersExistCondition.java
+++ b/sip-security/src/main/java/de/ikor/sip/foundation/security/authentication/SIPAuthProvidersExistCondition.java
@@ -3,41 +3,27 @@ package de.ikor.sip.foundation.security.authentication;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 
 import de.ikor.sip.foundation.security.config.SecurityConfigProperties.AuthProviderSettings;
-import java.util.List;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
 import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
 import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
-import org.springframework.boot.context.properties.bind.BindResult;
-import org.springframework.boot.context.properties.bind.Bindable;
-import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /** Condition class matching whether authentication providers are defined */
 public class SIPAuthProvidersExistCondition extends SpringBootCondition {
-  private static final Bindable<List<AuthProviderSettings>> PROVIDER_LIST =
-      Bindable.listOf(AuthProviderSettings.class);
 
   @Override
   public ConditionOutcome getMatchOutcome(
       ConditionContext context, AnnotatedTypeMetadata metadata) {
     ConditionOutcome outcome = ConditionOutcome.match();
-    String listPropertyName = "sip.security.authentication.auth-providers";
 
-    if (isEmpty(getAuthProviderSettingsList(context, listPropertyName))) {
+    if (isEmpty(AuthProviderSettings.getAuthProviderSettingsList(context))) {
       outcome =
           ConditionOutcome.noMatch(
               ConditionMessage.forCondition("SIP auth providers condition")
                   .didNotFind("property")
-                  .items(listPropertyName));
+                  .items(AuthProviderSettings.getListPropertyName()));
     }
     return outcome;
-  }
-
-  private List<AuthProviderSettings> getAuthProviderSettingsList(
-      ConditionContext context, String listPropertyName) {
-    BindResult<List<AuthProviderSettings>> bindResult =
-        Binder.get(context.getEnvironment()).bind(listPropertyName, PROVIDER_LIST);
-    return bindResult.orElse(null);
   }
 }

--- a/sip-security/src/main/java/de/ikor/sip/foundation/security/authentication/SIPAuthProvidersExistCondition.java
+++ b/sip-security/src/main/java/de/ikor/sip/foundation/security/authentication/SIPAuthProvidersExistCondition.java
@@ -17,12 +17,12 @@ public class SIPAuthProvidersExistCondition extends SpringBootCondition {
       ConditionContext context, AnnotatedTypeMetadata metadata) {
     ConditionOutcome outcome = ConditionOutcome.match();
 
-    if (isEmpty(AuthProviderSettings.getAuthProviderSettingsList(context))) {
+    if (isEmpty(AuthProviderSettings.bindFromPropertySource(context.getEnvironment()))) {
       outcome =
           ConditionOutcome.noMatch(
               ConditionMessage.forCondition("SIP auth providers condition")
                   .didNotFind("property")
-                  .items(AuthProviderSettings.getListPropertyName()));
+                  .items(AuthProviderSettings.getConfigurationPropertyName()));
     }
     return outcome;
   }

--- a/sip-security/src/main/java/de/ikor/sip/foundation/security/config/ConditionalOnSIPSecurityAuthenticationEnabled.java
+++ b/sip-security/src/main/java/de/ikor/sip/foundation/security/config/ConditionalOnSIPSecurityAuthenticationEnabled.java
@@ -1,11 +1,12 @@
 package de.ikor.sip.foundation.security.config;
 
+import de.ikor.sip.foundation.security.authentication.SIPAuthProvidersExistCondition;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Conditional;
 
 /**
  * Conditional annotation for enabled/disabling sip securitie's authentication feature
@@ -15,5 +16,5 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Documented
-@ConditionalOnProperty(name = "sip.security.authentication.enabled")
+@Conditional(SIPAuthProvidersExistCondition.class)
 public @interface ConditionalOnSIPSecurityAuthenticationEnabled {}

--- a/sip-security/src/main/java/de/ikor/sip/foundation/security/config/SecurityConfigProperties.java
+++ b/sip-security/src/main/java/de/ikor/sip/foundation/security/config/SecurityConfigProperties.java
@@ -77,12 +77,8 @@ public class SecurityConfigProperties {
     private static final Bindable<List<AuthProviderSettings>> PROVIDER_LIST =
         Bindable.listOf(AuthProviderSettings.class);
 
-    private static final String AUTH_PROVIDERS_PROPERTY_NAME =
+    public static final String AUTH_PROVIDERS_PROPERTY_NAME =
         "sip.security.authentication.auth-providers";
-
-    public static String getConfigurationPropertyName() {
-      return AUTH_PROVIDERS_PROPERTY_NAME;
-    }
 
     /**
      * Bind AuthProviderSettings from PropertySource

--- a/sip-security/src/main/java/de/ikor/sip/foundation/security/config/SecurityConfigProperties.java
+++ b/sip-security/src/main/java/de/ikor/sip/foundation/security/config/SecurityConfigProperties.java
@@ -13,8 +13,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.BindResult;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
-import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.core.io.Resource;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
@@ -77,16 +77,22 @@ public class SecurityConfigProperties {
     private static final Bindable<List<AuthProviderSettings>> PROVIDER_LIST =
         Bindable.listOf(AuthProviderSettings.class);
 
-    private static final String LIST_PROPERTY_NAME = "sip.security.authentication.auth-providers";
+    private static final String AUTH_PROVIDERS_PROPERTY_NAME =
+        "sip.security.authentication.auth-providers";
 
-    public static String getListPropertyName() {
-      return LIST_PROPERTY_NAME;
+    public static String getConfigurationPropertyName() {
+      return AUTH_PROVIDERS_PROPERTY_NAME;
     }
 
-    public static Collection<AuthProviderSettings> getAuthProviderSettingsList(
-        ConditionContext context) {
+    /**
+     * Bind AuthProviderSettings from PropertySource
+     *
+     * @param environment {@link Environment}
+     * @return collection of AuthProviderSettings or null if none exist
+     */
+    public static Collection<AuthProviderSettings> bindFromPropertySource(Environment environment) {
       BindResult<List<AuthProviderSettings>> bindResult =
-          Binder.get(context.getEnvironment()).bind(LIST_PROPERTY_NAME, PROVIDER_LIST);
+          Binder.get(environment).bind(AUTH_PROVIDERS_PROPERTY_NAME, PROVIDER_LIST);
       return bindResult.orElse(null);
     }
 

--- a/sip-security/src/main/java/de/ikor/sip/foundation/security/config/SecurityConfigProperties.java
+++ b/sip-security/src/main/java/de/ikor/sip/foundation/security/config/SecurityConfigProperties.java
@@ -2,6 +2,7 @@ package de.ikor.sip.foundation.security.config;
 
 import de.ikor.sip.foundation.security.authentication.SIPAuthenticationProvider;
 import de.ikor.sip.foundation.security.authentication.common.validators.SIPAlwaysAllowValidator;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -9,6 +10,10 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.BindResult;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
 import org.springframework.util.AntPathMatcher;
@@ -68,6 +73,22 @@ public class SecurityConfigProperties {
   @AllArgsConstructor
   public static class AuthProviderSettings {
     private final PathMatcher pathMatcher = new AntPathMatcher();
+
+    private static final Bindable<List<AuthProviderSettings>> PROVIDER_LIST =
+        Bindable.listOf(AuthProviderSettings.class);
+
+    private static final String LIST_PROPERTY_NAME = "sip.security.authentication.auth-providers";
+
+    public static String getListPropertyName() {
+      return LIST_PROPERTY_NAME;
+    }
+
+    public static Collection<AuthProviderSettings> getAuthProviderSettingsList(
+        ConditionContext context) {
+      BindResult<List<AuthProviderSettings>> bindResult =
+          Binder.get(context.getEnvironment()).bind(LIST_PROPERTY_NAME, PROVIDER_LIST);
+      return bindResult.orElse(null);
+    }
 
     /** The fully qualified classname of the current provider */
     private Class<?> classname = null;

--- a/sip-security/src/test/java/de/ikor/sip/foundation/security/authentication/SIPAuthProvidersExistConditionTest.java
+++ b/sip-security/src/test/java/de/ikor/sip/foundation/security/authentication/SIPAuthProvidersExistConditionTest.java
@@ -1,0 +1,53 @@
+package de.ikor.sip.foundation.security.authentication;
+
+import de.ikor.sip.foundation.security.authentication.basic.SIPBasicAuthAuthenticationProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SIPAuthProvidersExistConditionTest {
+
+    private SIPAuthProvidersExistCondition subject = new SIPAuthProvidersExistCondition();
+
+    @Test
+    void When_getMatchOutcomeWithExistingFlag_Expect_match() throws Exception {
+        // arrange
+        Class<?> annotatedClass = SIPBasicAuthAuthenticationProvider.class;
+
+        ConditionContext context = mock(ConditionContext.class);
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty(
+                "sip.security.authentication.auth-providers[0].classname", annotatedClass.getName());
+
+        when(context.getEnvironment()).thenReturn(environment);
+        AnnotatedTypeMetadata metadata = mock(AnnotatedTypeMetadata.class);
+
+        // act
+        ConditionOutcome result = subject.getMatchOutcome(context, metadata);
+
+        // assert
+        assertThat(result.isMatch()).isTrue();
+    }
+
+    @Test
+    void When_getMatchOutcomeWithNonExistingFlag_Expect_noMatch() throws Exception {
+        // arrange
+        ConditionContext context = mock(ConditionContext.class);
+        MockEnvironment environment = new MockEnvironment();
+
+        when(context.getEnvironment()).thenReturn(environment);
+        AnnotatedTypeMetadata metadata = mock(AnnotatedTypeMetadata.class);
+
+        // act
+        ConditionOutcome result = subject.getMatchOutcome(context, metadata);
+
+        // assert
+        assertThat(result.isMatch()).isFalse();
+    }
+}

--- a/sip-security/src/test/java/de/ikor/sip/foundation/security/authentication/SIPAuthProvidersExistConditionTest.java
+++ b/sip-security/src/test/java/de/ikor/sip/foundation/security/authentication/SIPAuthProvidersExistConditionTest.java
@@ -1,5 +1,9 @@
 package de.ikor.sip.foundation.security.authentication;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import de.ikor.sip.foundation.security.authentication.basic.SIPBasicAuthAuthenticationProvider;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
@@ -7,47 +11,43 @@ import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.mock.env.MockEnvironment;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 class SIPAuthProvidersExistConditionTest {
 
-    private SIPAuthProvidersExistCondition subject = new SIPAuthProvidersExistCondition();
+  private SIPAuthProvidersExistCondition subject = new SIPAuthProvidersExistCondition();
 
-    @Test
-    void When_getMatchOutcomeWithExistingFlag_Expect_match() throws Exception {
-        // arrange
-        Class<?> annotatedClass = SIPBasicAuthAuthenticationProvider.class;
+  @Test
+  void When_getMatchOutcomeWithExistingFlag_Expect_match() throws Exception {
+    // arrange
+    Class<?> annotatedClass = SIPBasicAuthAuthenticationProvider.class;
 
-        ConditionContext context = mock(ConditionContext.class);
-        MockEnvironment environment = new MockEnvironment();
-        environment.setProperty(
-                "sip.security.authentication.auth-providers[0].classname", annotatedClass.getName());
+    ConditionContext context = mock(ConditionContext.class);
+    MockEnvironment environment = new MockEnvironment();
+    environment.setProperty(
+        "sip.security.authentication.auth-providers[0].classname", annotatedClass.getName());
 
-        when(context.getEnvironment()).thenReturn(environment);
-        AnnotatedTypeMetadata metadata = mock(AnnotatedTypeMetadata.class);
+    when(context.getEnvironment()).thenReturn(environment);
+    AnnotatedTypeMetadata metadata = mock(AnnotatedTypeMetadata.class);
 
-        // act
-        ConditionOutcome result = subject.getMatchOutcome(context, metadata);
+    // act
+    ConditionOutcome result = subject.getMatchOutcome(context, metadata);
 
-        // assert
-        assertThat(result.isMatch()).isTrue();
-    }
+    // assert
+    assertThat(result.isMatch()).isTrue();
+  }
 
-    @Test
-    void When_getMatchOutcomeWithNonExistingFlag_Expect_noMatch() throws Exception {
-        // arrange
-        ConditionContext context = mock(ConditionContext.class);
-        MockEnvironment environment = new MockEnvironment();
+  @Test
+  void When_getMatchOutcomeWithNonExistingFlag_Expect_noMatch() throws Exception {
+    // arrange
+    ConditionContext context = mock(ConditionContext.class);
+    MockEnvironment environment = new MockEnvironment();
 
-        when(context.getEnvironment()).thenReturn(environment);
-        AnnotatedTypeMetadata metadata = mock(AnnotatedTypeMetadata.class);
+    when(context.getEnvironment()).thenReturn(environment);
+    AnnotatedTypeMetadata metadata = mock(AnnotatedTypeMetadata.class);
 
-        // act
-        ConditionOutcome result = subject.getMatchOutcome(context, metadata);
+    // act
+    ConditionOutcome result = subject.getMatchOutcome(context, metadata);
 
-        // assert
-        assertThat(result.isMatch()).isFalse();
-    }
+    // assert
+    assertThat(result.isMatch()).isFalse();
+  }
 }


### PR DESCRIPTION
# Description

Removed configuration property sip.security.authentication.enabled. Now it's only necessary to provide authentication providers list.

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested on an adapter with SIP security. sip.security.authentication.enabled not set in config, but auth-providers list is added. Check whether they are enabled.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing (regression) unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
