### PR TITLE
Changing health check scheduler and health check actuator calculations of the endpoint health statuses.

### DIFF
--- a/changelogs/feature/health_check_scheduler_update.json
+++ b/changelogs/feature/health_check_scheduler_update.json
@@ -1,0 +1,5 @@
+{
+  "author": "nikolag-ikor",
+  "pullrequestId": "37",
+  "message": "Removed health calculation from actuator health endpoint. Calculation of endpoints health is moved to health check scheduler instead."
+}

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/CamelEndpointHealthMonitor.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/CamelEndpointHealthMonitor.java
@@ -42,7 +42,7 @@ public class CamelEndpointHealthMonitor implements CompositeHealthContributor {
     return healthIndicators;
   }
 
-  public Iterator<NamedContributor<HealthContributor>> setupEndpointHealthIndicators() {
+  Iterator<NamedContributor<HealthContributor>> setupEndpointHealthIndicators() {
     Collection<Endpoint> endpoints = camelContext.getEndpoints();
     if (camelContext.getStatus().isStarted()) {
       this.healthIndicators =

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/CamelEndpointHealthMonitor.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/CamelEndpointHealthMonitor.java
@@ -9,10 +9,7 @@ import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Endpoint;
-import org.springframework.boot.actuate.health.CompositeHealthContributor;
-import org.springframework.boot.actuate.health.HealthContributor;
-import org.springframework.boot.actuate.health.HealthIndicator;
-import org.springframework.boot.actuate.health.NamedContributor;
+import org.springframework.boot.actuate.health.*;
 
 /**
  * {@link CamelEndpointHealthMonitor} is a central point in evaluating Health information of the
@@ -41,11 +38,11 @@ public class CamelEndpointHealthMonitor implements CompositeHealthContributor {
     return healthIndicators();
   }
 
-  synchronized Map<String, EndpointHealthIndicator> getHealthIndicators() {
+  public synchronized Map<String, EndpointHealthIndicator> getHealthIndicators() {
     return healthIndicators;
   }
 
-  Iterator<NamedContributor<HealthContributor>> setupEndpointHealthIndicators() {
+  public Iterator<NamedContributor<HealthContributor>> setupEndpointHealthIndicators() {
     Collection<Endpoint> endpoints = camelContext.getEndpoints();
     if (camelContext.getStatus().isStarted()) {
       this.healthIndicators =

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/EndpointHealthIndicator.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/EndpointHealthIndicator.java
@@ -15,6 +15,7 @@ import org.springframework.boot.actuate.health.HealthIndicator;
 public class EndpointHealthIndicator implements HealthContributor, HealthIndicator {
   private final Endpoint endpoint;
   private final Function<Endpoint, Health> healthFunction;
+  private Health health;
 
   /**
    * Returns the name of the endpoint. It will be used and visible in the health information report
@@ -33,6 +34,13 @@ public class EndpointHealthIndicator implements HealthContributor, HealthIndicat
    */
   @Override
   public Health health() {
-    return healthFunction.apply(this.endpoint);
+    return health;
+  }
+
+  /**
+   * Calculates health of the endpoint.
+   */
+  public void executeHealthCheck() {
+    this.health = healthFunction.apply(this.endpoint);
   }
 }

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/EndpointHealthIndicator.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/EndpointHealthIndicator.java
@@ -37,9 +37,7 @@ public class EndpointHealthIndicator implements HealthContributor, HealthIndicat
     return health;
   }
 
-  /**
-   * Calculates health of the endpoint.
-   */
+  /** Calculates health of the endpoint. */
   public void executeHealthCheck() {
     this.health = healthFunction.apply(this.endpoint);
   }

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheck.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheck.java
@@ -34,7 +34,6 @@ public class ScheduledHealthCheck {
   public void scheduledExecution() {
     Map<String, EndpointHealthIndicator> healthIndicators = monitor.getHealthIndicators();
 
-    healthIndicators.forEach(
-        ((s, endpointHealthIndicator) -> endpointHealthIndicator.executeHealthCheck()));
+    healthIndicators.values().forEach(EndpointHealthIndicator::executeHealthCheck);
   }
 }

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheck.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheck.java
@@ -1,34 +1,40 @@
 package de.ikor.sip.foundation.core.actuator.health.scheduler;
 
+import de.ikor.sip.foundation.core.actuator.health.CamelEndpointHealthMonitor;
+import de.ikor.sip.foundation.core.actuator.health.EndpointHealthIndicator;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.actuate.health.HealthEndpoint;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+
+import java.util.Map;
 
 /**
  * Scheduled execution for connection checks.
  *
  * <p>Switched off by default Default fixed delay (interval): every 15 minutes, or 900000ms Default
- * initial delay: 10 seconds, or 10000ms
+ * initial delay: 5 seconds, or 5000ms
  *
  * <p>sip.core.metrics.scheduled-health-check.enabled:false
  * sip.core.metrics.scheduled-health-check.fixed-delay:900000
- * sip.core.metrics.scheduled-health-check.initial-delay:10000
+ * sip.core.metrics.scheduled-health-check.initial-delay:5000
  */
 @Service
 @Slf4j
-@ConditionalOnExpression("${sip.core.metrics.scheduled-health-check.enabled:false}")
+@AllArgsConstructor
+@ConditionalOnExpression("${sip.core.metrics.scheduled-health-check.enabled:true}")
 public class ScheduledHealthCheck {
 
-  @Autowired private HealthEndpoint healthEndpoint;
+  private final CamelEndpointHealthMonitor monitor;
 
   /** Scheduled health check */
   @Scheduled(
       fixedDelayString = "${sip.core.metrics.scheduled-health-check.fixed-delay:900000}",
-      initialDelayString = "${sip.core.metrics.scheduled-health-check.initial-delay:10000}")
+      initialDelayString = "${sip.core.metrics.scheduled-health-check.initial-delay:5000}")
   public void scheduledExecution() {
-    log.info("sip.core.health.applicationstatus_{}", healthEndpoint.health().getStatus());
+    Map<String, EndpointHealthIndicator> healthIndicators = monitor.getHealthIndicators();
+
+    healthIndicators.forEach(((s, endpointHealthIndicator) -> endpointHealthIndicator.executeHealthCheck()));
   }
 }

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheck.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheck.java
@@ -13,10 +13,10 @@ import java.util.Map;
 /**
  * Scheduled execution for connection checks.
  *
- * <p>Switched off by default Default fixed delay (interval): every 15 minutes, or 900000ms Default
- * initial delay: 5 seconds, or 5000ms
+ * <p>Switched on by default. Default fixed delay (interval): every 15 minutes, or 900000ms
+ * Default initial delay: 5 seconds, or 5000ms
  *
- * <p>sip.core.metrics.scheduled-health-check.enabled:false
+ * <p>sip.core.metrics.scheduled-health-check.enabled:true
  * sip.core.metrics.scheduled-health-check.fixed-delay:900000
  * sip.core.metrics.scheduled-health-check.initial-delay:5000
  */

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheck.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheck.java
@@ -4,7 +4,6 @@ import de.ikor.sip.foundation.core.actuator.health.CamelEndpointHealthMonitor;
 import de.ikor.sip.foundation.core.actuator.health.EndpointHealthIndicator;
 import java.util.Map;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -20,7 +19,6 @@ import org.springframework.stereotype.Service;
  * sip.core.metrics.scheduled-health-check.initial-delay:5000
  */
 @Service
-@Slf4j
 @AllArgsConstructor
 @ConditionalOnExpression("${sip.core.metrics.scheduled-health-check.enabled:true}")
 public class ScheduledHealthCheck {

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheck.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheck.java
@@ -2,19 +2,18 @@ package de.ikor.sip.foundation.core.actuator.health.scheduler;
 
 import de.ikor.sip.foundation.core.actuator.health.CamelEndpointHealthMonitor;
 import de.ikor.sip.foundation.core.actuator.health.EndpointHealthIndicator;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
-import java.util.Map;
-
 /**
  * Scheduled execution for connection checks.
  *
- * <p>Switched on by default. Default fixed delay (interval): every 15 minutes, or 900000ms
- * Default initial delay: 5 seconds, or 5000ms
+ * <p>Switched on by default. Default fixed delay (interval): every 15 minutes, or 900000ms Default
+ * initial delay: 5 seconds, or 5000ms
  *
  * <p>sip.core.metrics.scheduled-health-check.enabled:true
  * sip.core.metrics.scheduled-health-check.fixed-delay:900000
@@ -35,6 +34,7 @@ public class ScheduledHealthCheck {
   public void scheduledExecution() {
     Map<String, EndpointHealthIndicator> healthIndicators = monitor.getHealthIndicators();
 
-    healthIndicators.forEach(((s, endpointHealthIndicator) -> endpointHealthIndicator.executeHealthCheck()));
+    healthIndicators.forEach(
+        ((s, endpointHealthIndicator) -> endpointHealthIndicator.executeHealthCheck()));
   }
 }

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheckConfiguration.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheckConfiguration.java
@@ -23,9 +23,4 @@ public class ScheduledHealthCheckConfiguration {
       HealthGaugeConfiguration healthGaugeConfiguration) {
     return new HealthCheckMetricsConfiguration(registry, healthEndpoint, healthGaugeConfiguration);
   }
-
-  @Bean
-  ScheduledHealthCheck createScheduledHealthCheck() {
-    return new ScheduledHealthCheck();
-  }
 }

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/health/EndpointHealthIndicatorTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/health/EndpointHealthIndicatorTest.java
@@ -12,10 +12,11 @@ import org.springframework.boot.actuate.health.Health;
 
 class EndpointHealthIndicatorTest {
 
-  private EndpointHealthIndicator endpointHealthIndicator;
+  private static final String ENDPOINT_URI = "uri";
+
+  private EndpointHealthIndicator subject;
   private Endpoint endpoint;
   private Health health;
-  private static final String ENDPOINT_URI = "uri";
 
   @BeforeEach
   void setup() {
@@ -25,47 +26,47 @@ class EndpointHealthIndicatorTest {
         endpoint -> {
           return health;
         };
-    endpointHealthIndicator = new EndpointHealthIndicator(endpoint, healthFunction);
+    subject = new EndpointHealthIndicator(endpoint, healthFunction);
   }
 
   @Test
-  void WHEN_name_EXPECT_endpointNameReturned() {
+  void WHEN_fetchingName_EXPECT_endpointNameReturned() {
     // arrange
     when(endpoint.getEndpointUri()).thenReturn(ENDPOINT_URI);
 
     // act
-    String nameSubject = endpointHealthIndicator.name();
+    String nameResult = subject.name();
 
     // assert
-    assertThat(nameSubject).isEqualTo(ENDPOINT_URI);
+    assertThat(nameResult).isEqualTo(ENDPOINT_URI);
   }
 
   @Test
   void WHEN_health_WITH_NoHealthCalculation_THEN_NoHealth() {
     // act
-    Health healthSubject = endpointHealthIndicator.health();
+    Health healthResult = subject.health();
 
     // assert
-    assertThat(healthSubject).isNull();
+    assertThat(healthResult).isNull();
   }
 
   @Test
   void WHEN_health_WITH_HealthCalculation_THEN_ReturnHealth() {
     // act
-    endpointHealthIndicator.executeHealthCheck();
-    Health healthSubject = endpointHealthIndicator.health();
+    subject.executeHealthCheck();
+    Health healthResult = subject.health();
 
     // assert
-    assertThat(healthSubject).isEqualTo(health);
+    assertThat(healthResult).isEqualTo(health);
   }
 
   @Test
   void WHEN_executeHealthCheck_EXPECT_HealthIsCalculated() {
     // act
-    endpointHealthIndicator.executeHealthCheck();
-    Health healthSubject = endpointHealthIndicator.getHealth(false);
+    subject.executeHealthCheck();
+    Health healthResult = subject.getHealth(false);
 
     // assert
-    assertThat(healthSubject).isEqualTo(health);
+    assertThat(healthResult).isEqualTo(health);
   }
 }

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/health/EndpointHealthIndicatorTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/health/EndpointHealthIndicatorTest.java
@@ -12,35 +12,60 @@ import org.springframework.boot.actuate.health.Health;
 
 class EndpointHealthIndicatorTest {
 
-  EndpointHealthIndicator endpointHealthIndicator;
-  Endpoint endpoint;
-  Health health;
-  private static final String ENDPOINT_NAME = "name";
+  private EndpointHealthIndicator endpointHealthIndicator;
+  private Endpoint endpoint;
+  private Health health;
+  private static final String ENDPOINT_URI = "uri";
 
   @BeforeEach
   void setup() {
     endpoint = mock(Endpoint.class);
     health = Health.up().build();
     Function<Endpoint, Health> healthFunction =
-        endpoint1 -> {
+        endpoint -> {
           return health;
         };
     endpointHealthIndicator = new EndpointHealthIndicator(endpoint, healthFunction);
   }
 
   @Test
-  void name() {
+  void WHEN_name_EXPECT_endpointNameReturned() {
+    // arrange
+    when(endpoint.getEndpointUri()).thenReturn(ENDPOINT_URI);
+
     // act
-    when(endpoint.getEndpointUri()).thenReturn(ENDPOINT_NAME);
+    String nameSubject = endpointHealthIndicator.name();
 
     // assert
-    assertThat(endpointHealthIndicator.name()).isEqualTo(ENDPOINT_NAME);
+    assertThat(nameSubject).isEqualTo(ENDPOINT_URI);
   }
 
   @Test
-  void health() {
+  void WHEN_health_WITH_NoHealthCalculation_THEN_NoHealth() {
+    // act
+    Health healthSubject = endpointHealthIndicator.health();
 
     // assert
-    assertThat(health).isEqualTo(endpointHealthIndicator.health());
+    assertThat(healthSubject).isNull();
+  }
+
+  @Test
+  void WHEN_health_WITH_HealthCalculation_THEN_ReturnHealth() {
+    // act
+    endpointHealthIndicator.executeHealthCheck();
+    Health healthSubject = endpointHealthIndicator.health();
+
+    // assert
+    assertThat(healthSubject).isEqualTo(health);
+  }
+
+  @Test
+  void WHEN_executeHealthCheck_EXPECT_HealthIsCalculated() {
+    // act
+    endpointHealthIndicator.executeHealthCheck();
+    Health healthSubject = endpointHealthIndicator.getHealth(false);
+
+    // assert
+    assertThat(healthSubject).isEqualTo(health);
   }
 }

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheckTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheckTest.java
@@ -39,6 +39,6 @@ class ScheduledHealthCheckTest {
     Health healthResult = healthIndicators.get(ENDPOINT).getHealth(false);
 
     // assert
-    assertThat(healthResult).isEqualTo(healthFunction);
+    assertThat(healthResult).isEqualTo(Health.up().build());
   }
 }

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheckTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheckTest.java
@@ -16,9 +16,11 @@ import org.springframework.boot.actuate.health.Health;
 class ScheduledHealthCheckTest {
 
   private static final String ENDPOINT = "endpoint";
+  private static final Health HEALTH_STATUS_UP = Health.up().build();
 
   private CamelEndpointHealthMonitor camelEndpointHealthMonitor;
   private ScheduledHealthCheck scheduledHealthCheckSubject;
+
 
   @Test
   void WHEN_scheduledExecution_EXPECT_HealthEndpointsAreCalculated() {
@@ -27,7 +29,7 @@ class ScheduledHealthCheckTest {
     scheduledHealthCheckSubject = new ScheduledHealthCheck(camelEndpointHealthMonitor);
 
     Map<String, EndpointHealthIndicator> healthIndicators = new HashMap<>();
-    Function<Endpoint, Health> healthFunction = endpoint -> Health.up().build();
+    Function<Endpoint, Health> healthFunction = endpoint -> HEALTH_STATUS_UP;
     EndpointHealthIndicator endpointHealthIndicator =
         new EndpointHealthIndicator(mock(Endpoint.class), healthFunction);
     healthIndicators.put(ENDPOINT, endpointHealthIndicator);
@@ -39,6 +41,6 @@ class ScheduledHealthCheckTest {
     Health healthResult = healthIndicators.get(ENDPOINT).getHealth(false);
 
     // assert
-    assertThat(healthResult).isEqualTo(Health.up().build());
+    assertThat(healthResult).isEqualTo(HEALTH_STATUS_UP);
   }
 }

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheckTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheckTest.java
@@ -15,16 +15,16 @@ import org.springframework.boot.actuate.health.Health;
 
 class ScheduledHealthCheckTest {
 
-  private CamelEndpointHealthMonitor camelEndpointHealthMonitor;
-  private ScheduledHealthCheck scheduledHealthCheck;
-
   private static final String ENDPOINT = "endpoint";
+
+  private CamelEndpointHealthMonitor camelEndpointHealthMonitor;
+  private ScheduledHealthCheck scheduledHealthCheckSubject;
 
   @Test
   void WHEN_scheduledExecution_EXPECT_HealthEndpointsAreCalculated() {
     // arrange
     camelEndpointHealthMonitor = mock(CamelEndpointHealthMonitor.class);
-    scheduledHealthCheck = new ScheduledHealthCheck(camelEndpointHealthMonitor);
+    scheduledHealthCheckSubject = new ScheduledHealthCheck(camelEndpointHealthMonitor);
 
     Map<String, EndpointHealthIndicator> healthIndicators = new HashMap<>();
     Function<Endpoint, Health> healthFunction =
@@ -38,10 +38,10 @@ class ScheduledHealthCheckTest {
     when(camelEndpointHealthMonitor.getHealthIndicators()).thenReturn(healthIndicators);
 
     // act
-    scheduledHealthCheck.scheduledExecution();
-    Health healthSubject = healthIndicators.get(ENDPOINT).getHealth(false);
+    scheduledHealthCheckSubject.scheduledExecution();
+    Health healthResult = healthIndicators.get(ENDPOINT).getHealth(false);
 
     // assert
-    assertThat(healthSubject).isEqualTo(Health.up().build());
+    assertThat(healthResult).isEqualTo(Health.up().build());
   }
 }

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheckTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheckTest.java
@@ -21,7 +21,6 @@ class ScheduledHealthCheckTest {
   private CamelEndpointHealthMonitor camelEndpointHealthMonitor;
   private ScheduledHealthCheck scheduledHealthCheckSubject;
 
-
   @Test
   void WHEN_scheduledExecution_EXPECT_HealthEndpointsAreCalculated() {
     // arrange

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheckTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheckTest.java
@@ -1,45 +1,44 @@
 package de.ikor.sip.foundation.core.actuator.health.scheduler;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
-import java.util.List;
+import de.ikor.sip.foundation.core.actuator.health.CamelEndpointHealthMonitor;
+import de.ikor.sip.foundation.core.actuator.health.EndpointHealthIndicator;
+import org.apache.camel.Endpoint;
 import org.junit.jupiter.api.Test;
-import org.slf4j.LoggerFactory;
-import org.springframework.boot.actuate.health.HealthComponent;
-import org.springframework.boot.actuate.health.HealthEndpoint;
-import org.springframework.boot.actuate.health.Status;
-import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.boot.actuate.health.Health;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
 
 class ScheduledHealthCheckTest {
 
+  private CamelEndpointHealthMonitor camelEndpointHealthMonitor;
+  private ScheduledHealthCheck scheduledHealthCheck;
+
+  private static final String ENDPOINT = "endpoint";
+
   @Test
-  void scheduledExecution() {
+  void WHEN_scheduledExecution_EXPECT_HealthEndpointsAreCalculated() {
     // arrange
-    ListAppender<ILoggingEvent> listAppender;
-    Logger logger = (Logger) LoggerFactory.getLogger(ScheduledHealthCheck.class);
-    listAppender = new ListAppender<>();
-    listAppender.start();
-    logger.addAppender(listAppender);
-    HealthEndpoint endpoint = mock(HealthEndpoint.class);
-    HealthComponent component = mock(HealthComponent.class);
-    when(endpoint.health()).thenReturn(component);
-    when(component.getStatus()).thenReturn(Status.UP);
-    ScheduledHealthCheck scheduledHealthCheck = new ScheduledHealthCheck();
-    ReflectionTestUtils.setField(scheduledHealthCheck, "healthEndpoint", endpoint);
-    List<ILoggingEvent> logsList = listAppender.list;
+    camelEndpointHealthMonitor = mock(CamelEndpointHealthMonitor.class);
+    scheduledHealthCheck = new ScheduledHealthCheck(camelEndpointHealthMonitor);
+
+    Map<String, EndpointHealthIndicator> healthIndicators = new HashMap<>();
+    Function<Endpoint, Health> healthFunction = (x) -> { return (new Health.Builder()).up().build(); };
+    EndpointHealthIndicator endpointHealthIndicator = new EndpointHealthIndicator(mock(Endpoint.class), healthFunction);
+    healthIndicators.put(ENDPOINT, endpointHealthIndicator);
+
+    when(camelEndpointHealthMonitor.getHealthIndicators()).thenReturn(healthIndicators);
 
     // act
     scheduledHealthCheck.scheduledExecution();
+    Health healthSubject = healthIndicators.get(ENDPOINT).getHealth(false);
 
     // assert
-    assertThat(logsList.get(0).getMessage()).isEqualTo("sip.core.health.applicationstatus_{}");
-    assertThat(logsList.get(0).getLevel()).isEqualTo(Level.INFO);
+    assertThat(healthSubject).isEqualTo(Health.up().build());
   }
 }

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheckTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheckTest.java
@@ -6,13 +6,12 @@ import static org.mockito.Mockito.when;
 
 import de.ikor.sip.foundation.core.actuator.health.CamelEndpointHealthMonitor;
 import de.ikor.sip.foundation.core.actuator.health.EndpointHealthIndicator;
-import org.apache.camel.Endpoint;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.actuate.health.Health;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
+import org.apache.camel.Endpoint;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.health.Health;
 
 class ScheduledHealthCheckTest {
 
@@ -28,8 +27,12 @@ class ScheduledHealthCheckTest {
     scheduledHealthCheck = new ScheduledHealthCheck(camelEndpointHealthMonitor);
 
     Map<String, EndpointHealthIndicator> healthIndicators = new HashMap<>();
-    Function<Endpoint, Health> healthFunction = (x) -> { return (new Health.Builder()).up().build(); };
-    EndpointHealthIndicator endpointHealthIndicator = new EndpointHealthIndicator(mock(Endpoint.class), healthFunction);
+    Function<Endpoint, Health> healthFunction =
+        endpoint -> {
+          return (new Health.Builder()).up().build();
+        };
+    EndpointHealthIndicator endpointHealthIndicator =
+        new EndpointHealthIndicator(mock(Endpoint.class), healthFunction);
     healthIndicators.put(ENDPOINT, endpointHealthIndicator);
 
     when(camelEndpointHealthMonitor.getHealthIndicators()).thenReturn(healthIndicators);

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheckTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheckTest.java
@@ -27,10 +27,7 @@ class ScheduledHealthCheckTest {
     scheduledHealthCheckSubject = new ScheduledHealthCheck(camelEndpointHealthMonitor);
 
     Map<String, EndpointHealthIndicator> healthIndicators = new HashMap<>();
-    Function<Endpoint, Health> healthFunction =
-        endpoint -> {
-          return (new Health.Builder()).up().build();
-        };
+    Function<Endpoint, Health> healthFunction = endpoint -> Health.up().build();
     EndpointHealthIndicator endpointHealthIndicator =
         new EndpointHealthIndicator(mock(Endpoint.class), healthFunction);
     healthIndicators.put(ENDPOINT, endpointHealthIndicator);
@@ -42,6 +39,6 @@ class ScheduledHealthCheckTest {
     Health healthResult = healthIndicators.get(ENDPOINT).getHealth(false);
 
     // assert
-    assertThat(healthResult).isEqualTo(Health.up().build());
+    assertThat(healthResult).isEqualTo(healthFunction);
   }
 }


### PR DESCRIPTION
# Description

Calculation of endpoint healths is removed from the actuator/health. Under actuator/health last info about health is fetched from the result of health check scheduler, which actually calculates the endpoint health check statuses.

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Create some endpoints within the Camel routes. Create some health check functions and register them under appropriate uri pattern as well.
Start the application.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing (regression) unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
