### PR TITLE
Feature/sip 869 add changelog.md file to archetype

### DIFF
--- a/changelogs/feature/add_changelog_file.json
+++ b/changelogs/feature/add_changelog_file.json
@@ -1,0 +1,5 @@
+{
+  "author": "Dzuci",
+  "pullrequestId": "41",
+  "message": "Added changelog.md and adapter-description.md"
+}

--- a/sip-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/sip-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -66,6 +66,8 @@ under the License.
             <includes>
                 <include>.gitignore</include>
                 <include>README.md</include>
+                <include>changelog.md</include>
+
             </includes>
         </fileSet>
     </fileSets>

--- a/sip-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/sip-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -67,7 +67,7 @@ under the License.
                 <include>.gitignore</include>
                 <include>README.md</include>
                 <include>changelog.md</include>
-
+                <include>adapter-description.md</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/sip-archetype/src/main/resources/archetype-resources/README.md
+++ b/sip-archetype/src/main/resources/archetype-resources/README.md
@@ -8,6 +8,8 @@ This is an auto-generated project and you can find more information about develo
 sip framework concept at:
 https://git.ikor.cloud/sip-2-product/sip/sip-framework/-/blob/develop/README.md
 
+Please use this document to describe how to build and run your adapter.
+
 We encourage you to explore our features and hope you enjoy developing your adapter with SIP.
 
 We would also like to have you in our team by contributing to the framework. Please check here how to contribute:

--- a/sip-archetype/src/main/resources/archetype-resources/adapter-description.md
+++ b/sip-archetype/src/main/resources/archetype-resources/adapter-description.md
@@ -1,3 +1,3 @@
 # SIP Adapter Description
 
-Please describe the workflow of your adapter.
+This file should contain details about what your adapter does, which services does it connect, what is the workflow etc.

--- a/sip-archetype/src/main/resources/archetype-resources/adapter-description.md
+++ b/sip-archetype/src/main/resources/archetype-resources/adapter-description.md
@@ -1,0 +1,5 @@
+# Welcome!
+
+**Thank you for using SIP Framework!**
+
+Please describe your adapter workflow.

--- a/sip-archetype/src/main/resources/archetype-resources/adapter-description.md
+++ b/sip-archetype/src/main/resources/archetype-resources/adapter-description.md
@@ -1,5 +1,3 @@
-# Welcome!
+# SIP Adapter Description
 
-**Thank you for using SIP Framework!**
-
-Please describe your adapter workflow.
+Please describe the workflow of your adapter.

--- a/sip-archetype/src/main/resources/archetype-resources/changelog.md
+++ b/sip-archetype/src/main/resources/archetype-resources/changelog.md
@@ -1,11 +1,15 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-The format is based on Keep a Changelog
-and this project adheres to Semantic Versioning.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
 
 --
 
-[x.x.x] yyyy-mm-dd
-##  Added
-addition
+## [x.x.x] yyyy-mm-dd
+
+### Added
+
+### Changed
+
+### Removed

--- a/sip-archetype/src/main/resources/archetype-resources/changelog.md
+++ b/sip-archetype/src/main/resources/archetype-resources/changelog.md
@@ -1,0 +1,3 @@
+# Welcome!
+
+**Thank you for using SIP Framework!**

--- a/sip-archetype/src/main/resources/archetype-resources/changelog.md
+++ b/sip-archetype/src/main/resources/archetype-resources/changelog.md
@@ -1,3 +1,11 @@
-# Welcome!
+# Change Log
+All notable changes to this project will be documented in this file.
 
-**Thank you for using SIP Framework!**
+The format is based on Keep a Changelog
+and this project adheres to Semantic Versioning.
+
+--
+
+[x.x.x] yyyy-mm-dd
+##  Added
+addition


### PR DESCRIPTION
# Description

Added changelog.md and adapter-description.md files to the project structure. The files contain generic messages

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- When a new adapter is created, it should contain changelog.md and adapter-description.md with generic messages

**Test Configuration**:
* SIP Framework version(s):
* Other configuration:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing (regression) unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
