### PR TITLE
Scheduled health check incorrect condition 

### DIFF
--- a/changelogs/bugfix/health-check-incorrect-condition.json
+++ b/changelogs/bugfix/health-check-incorrect-condition.json
@@ -1,0 +1,5 @@
+{
+  "author": "Nemikor",
+  "pullrequestId": 54,
+  "message": "Updated HealthCheckEnabledCondition to match when HealthEndpoint is enabled"
+}

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/scheduler/HealthCheckEnabledCondition.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/scheduler/HealthCheckEnabledCondition.java
@@ -6,10 +6,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.actuate.health.HealthEndpoint;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
-@ConditionalOnExpression("${sip.core.metrics.external-endpoint-health-check.enabled}")
+@ConditionalOnProperty("sip.core.metrics.external-endpoint-health-check.enabled")
 @ConditionalOnAvailableEndpoint(endpoint = HealthEndpoint.class)
 public @interface HealthCheckEnabledCondition {}

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/scheduler/HealthCheckEnabledCondition.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/scheduler/HealthCheckEnabledCondition.java
@@ -4,10 +4,12 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
+import org.springframework.boot.actuate.health.HealthEndpoint;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
-@ConditionalOnExpression(
-    "${sip.core.metrics.external-endpoint-health-check.enabled} and '${management.endpoints.web.exposure.include}'.contains('health')")
+@ConditionalOnExpression("${sip.core.metrics.external-endpoint-health-check.enabled}")
+@ConditionalOnAvailableEndpoint(endpoint = HealthEndpoint.class)
 public @interface HealthCheckEnabledCondition {}


### PR DESCRIPTION
# Description

Scheduled health check should only be available if actuator HealthEndpoint is enabled. Previous condition matched only if "health" was found in configuration property "management.endpoints.web.exposure.include", but not if "*" was set.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Checked whether scheduled health check and is enabled and if "sip.core.metrics.health" metric exists with different configuration:
- management.endpoints.web.exposure.include: health,{other}
- management.endpoints.web.exposure.include: "*"
- management.endpoints.web.exposure.include: {other}

and whether they are disabled when "sip.core.metrics.external-endpoint-health-check.enabled" is set to false.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing (regression) unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
