### PR TITLE
Added conditional checks for standalone testing

### DIFF
--- a/changelogs/bugfix/additional-conditional-checks.json
+++ b/changelogs/bugfix/additional-conditional-checks.json
@@ -1,0 +1,5 @@
+{
+  "author": "MartinBuchheimIkor",
+  "pullrequestId": 61,
+  "message": "Added Conditional-checks that allow to start a Spring Boot application from the test sources without the need for a CamelContext (which is typically provided by the adapter code)"
+}

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/CamelEndpointHealthConfiguration.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/CamelEndpointHealthConfiguration.java
@@ -2,6 +2,7 @@ package de.ikor.sip.foundation.core.actuator.health;
 
 import java.util.List;
 import org.apache.camel.CamelContext;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -10,6 +11,7 @@ import org.springframework.context.annotation.Configuration;
  * with {@link CamelEndpointHealthMonitor}.
  */
 @Configuration
+@ConditionalOnBean(CamelContext.class)
 public class CamelEndpointHealthConfiguration {
 
   @Bean

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/HealthMonitorSetup.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/HealthMonitorSetup.java
@@ -1,6 +1,8 @@
 package de.ikor.sip.foundation.core.actuator.health;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -9,6 +11,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.processor.SendProcessor;
 import org.apache.commons.collections4.MapIterator;
 import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -19,6 +22,7 @@ import org.springframework.stereotype.Component;
  */
 @Slf4j
 @Component
+@ConditionalOnBean(CamelContext.class)
 @AllArgsConstructor
 public class HealthMonitorSetup {
   private final CamelContext camelContext;

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/scheduler/HealthCheckMetricsConfiguration.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/scheduler/HealthCheckMetricsConfiguration.java
@@ -4,6 +4,7 @@ import de.ikor.sip.foundation.core.actuator.health.CamelEndpointHealthMonitor;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.boot.actuate.health.Status;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Configuration;
 
 /**
@@ -11,6 +12,7 @@ import org.springframework.context.annotation.Configuration;
  * this
  */
 @Configuration
+@ConditionalOnBean(CamelEndpointHealthMonitor.class)
 @HealthCheckEnabledCondition
 public class HealthCheckMetricsConfiguration {
 

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheck.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/scheduler/ScheduledHealthCheck.java
@@ -4,6 +4,7 @@ import de.ikor.sip.foundation.core.actuator.health.CamelEndpointHealthMonitor;
 import de.ikor.sip.foundation.core.actuator.health.EndpointHealthIndicator;
 import java.util.Map;
 import lombok.AllArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Service;
  * sip.core.metrics.external-endpoint-health-check.scheduler.initial-delay:5000
  */
 @Service
+@ConditionalOnBean(CamelEndpointHealthMonitor.class)
 @AllArgsConstructor
 @EnableScheduling
 @HealthCheckEnabledCondition

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/routes/AdapterRouteEndpoint.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/routes/AdapterRouteEndpoint.java
@@ -11,6 +11,7 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.Route;
 import org.apache.camel.api.management.ManagedCamelContext;
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.PostMapping;
  * plenty of details about each one of them.
  */
 @Component
+@ConditionalOnBean(CamelContext.class)
 @RestControllerEndpoint(id = "adapter-routes")
 public class AdapterRouteEndpoint {
   private final CamelContext camelContext;

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/proxies/ProcessorProxyConfiguration.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/proxies/ProcessorProxyConfiguration.java
@@ -4,11 +4,13 @@ import javax.annotation.PostConstruct;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.CamelContext;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Configuration;
 
 /** Configuration for ProcessorProxy */
 @Slf4j
 @Configuration
+@ConditionalOnBean(CamelContext.class)
 @AllArgsConstructor
 public class ProcessorProxyConfiguration {
   private final CamelContext camelContext;

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/trace/TrafficTracerController.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/trace/TrafficTracerController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.camel.CamelContext;
 import org.apache.camel.support.processor.DefaultExchangeFormatterConfigurer;
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 /** Endpoint to get TraceHistory */
 @Component
+@ConditionalOnBean(CamelContext.class)
 @RequiredArgsConstructor
 @RestControllerEndpoint(id = "tracing")
 public class TrafficTracerController {

--- a/sip-security/src/main/java/de/ikor/sip/foundation/security/config/CamelSslClientConfiguration.java
+++ b/sip-security/src/main/java/de/ikor/sip/foundation/security/config/CamelSslClientConfiguration.java
@@ -4,6 +4,7 @@ import javax.annotation.PostConstruct;
 import lombok.AllArgsConstructor;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.http.HttpComponent;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 
@@ -13,6 +14,7 @@ import org.springframework.context.annotation.Configuration;
  * @author thomas.stieglmaier
  */
 @Configuration
+@ConditionalOnBean(CamelContext.class)
 @ConditionalOnProperty(name = "sip.security.ssl.client.enabled", havingValue = "true")
 @AllArgsConstructor
 public class CamelSslClientConfiguration {


### PR DESCRIPTION
Added plenty of conditionals that allow to run a spring-boot application from the foundation core package.

Mostly, conditional checks for existence of CamelContext bean have been added, as this context is typically created by the adapter definition itself through creating the routes, and is therefore not available when testing directly in the core package.

With these changes, a test-application can directly be started from the core test-packages, so unit tests against a running application are possible.

No new code besides the added annotations - all tests still run OK.