### PR TITLE
SIP-983|loading SIP security config by default

### DIFF
--- a/changelogs/bugfix/spring-security-default-config.json
+++ b/changelogs/bugfix/spring-security-default-config.json
@@ -1,0 +1,5 @@
+{
+  "author": "LetoBukarica",
+  "pullrequestId": "65",
+  "message": "Enabled SIP SecurityConfig always - removed the @ConditionalOnSIPSecurityAuthenticationEnabled"
+}

--- a/sip-security/src/main/java/de/ikor/sip/foundation/security/config/SecurityConfig.java
+++ b/sip-security/src/main/java/de/ikor/sip/foundation/security/config/SecurityConfig.java
@@ -67,16 +67,16 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     List<Class<?>> autowiredAuthProviders =
         authProviders.stream().map(Object::getClass).collect(Collectors.toList());
 
-    List<Class<?>> missingProvidersFromConfig =
+    List<Class<?>> providersUnavailableAtRuntime =
         config.getAuthProviders().stream()
             .map(AuthProviderSettings::getClassname)
             .filter(a -> !autowiredAuthProviders.contains(a))
             .collect(Collectors.toList());
 
-    if (!missingProvidersFromConfig.isEmpty()) {
+    if (!providersUnavailableAtRuntime.isEmpty()) {
       throw new IllegalStateException(
           "Some providers declared in the config are not available in runtime: "
-              + missingProvidersFromConfig);
+              + providersUnavailableAtRuntime);
     }
 
     if (configHasDuplicateAuthProviders()) {

--- a/sip-security/src/main/java/de/ikor/sip/foundation/security/config/SecurityConfig.java
+++ b/sip-security/src/main/java/de/ikor/sip/foundation/security/config/SecurityConfig.java
@@ -43,7 +43,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
    * @param config SIP Security config
    * @param tokenExtractors (optional) registered token extractors filled by authProviders
    */
-  // TODO: FILL this up
   @Autowired
   public SecurityConfig(
       Optional<List<SIPAuthenticationProvider<?>>> authProviders,

--- a/sip-security/src/main/java/de/ikor/sip/foundation/security/config/SecurityConfig.java
+++ b/sip-security/src/main/java/de/ikor/sip/foundation/security/config/SecurityConfig.java
@@ -4,7 +4,9 @@ import de.ikor.sip.foundation.security.authentication.CompositeAuthenticationFil
 import de.ikor.sip.foundation.security.authentication.SIPAuthenticationProvider;
 import de.ikor.sip.foundation.security.authentication.common.extractors.TokenExtractors;
 import de.ikor.sip.foundation.security.config.SecurityConfigProperties.AuthProviderSettings;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -24,15 +26,36 @@ import org.springframework.security.web.authentication.www.BasicAuthenticationFi
  *
  * @author thomas.stieglmaier
  */
-@ConditionalOnSIPSecurityAuthenticationEnabled
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
-  @Autowired private List<SIPAuthenticationProvider<?>> authProviders;
-  @Autowired private SecurityConfigProperties config;
-  @Autowired private TokenExtractors tokenExtractors;
+  private final List<SIPAuthenticationProvider<?>> authProviders;
 
+  private final SecurityConfigProperties config;
+
+  private final TokenExtractors tokenExtractors;
+
+  /**
+   * Autowired constructor for creating SIP Security Configuration
+   *
+   * @param authProviders (optional) list of auth providers defined in the config
+   * @param config SIP Security config
+   * @param tokenExtractors (optional) registered token extractors filled by authProviders
+   */
+  // TODO: FILL this up
+  @Autowired
+  public SecurityConfig(
+      Optional<List<SIPAuthenticationProvider<?>>> authProviders,
+      SecurityConfigProperties config,
+      Optional<TokenExtractors> tokenExtractors) {
+    super();
+    this.authProviders = authProviders.orElse(Collections.emptyList());
+    this.config = config;
+    this.tokenExtractors = tokenExtractors.orElse(null);
+  }
+
+  /** Register Spring-security provided authenticationManager as a @Bean */
   @Bean
   @Override
   public AuthenticationManager authenticationManagerBean() throws Exception {
@@ -40,29 +63,29 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
   }
 
   @Override
-  protected void configure(AuthenticationManagerBuilder authManagerBuilder) throws Exception {
-    List<Class<?>> existingAuthProviderClasses =
+  protected void configure(AuthenticationManagerBuilder authManagerBuilder)
+      throws IllegalStateException {
+    List<Class<?>> autowiredAuthProviders =
         authProviders.stream().map(Object::getClass).collect(Collectors.toList());
-    List<Class<?>> missingAuthProviders =
+
+    List<Class<?>> missingProvidersFromConfig =
         config.getAuthProviders().stream()
             .map(AuthProviderSettings::getClassname)
-            .filter(a -> !existingAuthProviderClasses.contains(a))
+            .filter(a -> !autowiredAuthProviders.contains(a))
             .collect(Collectors.toList());
 
-    if (!missingAuthProviders.isEmpty()) {
+    if (!missingProvidersFromConfig.isEmpty()) {
       throw new IllegalStateException(
-          "Some configured auth providers are not available in code: " + missingAuthProviders);
+          "Some providers declared in the config are not available in runtime: "
+              + missingProvidersFromConfig);
     }
 
-    if (config.getAuthProviders().size()
-        > config.getAuthProviders().stream()
-            .map(AuthProviderSettings::getClassname)
-            .distinct()
-            .count()) {
+    if (configHasDuplicateAuthProviders()) {
       throw new IllegalStateException(
           "Each auth provider may only be configured once, duplicates are not allowed");
     }
 
+    // Register all auth providers that exist in the config
     authProviders.stream()
         .filter(
             a ->
@@ -72,12 +95,20 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         .forEach(authManagerBuilder::authenticationProvider);
   }
 
+  private boolean configHasDuplicateAuthProviders() {
+    return config.getAuthProviders().size()
+        > config.getAuthProviders().stream()
+            .map(AuthProviderSettings::getClassname)
+            .distinct()
+            .count();
+  }
+
   @Override
   protected void configure(HttpSecurity http) throws Exception {
     // disable sessions completely
     http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
-    // add our composite authentication filter for all requests (besides the ones ignored separately
+    // add our composite authentication Filter for all requests (besides the ones ignored separately
     // in the WebSecurity configure method
     http.addFilterAt(
             new CompositeAuthenticationFilter(tokenExtractors, config, authenticationManagerBean()),
@@ -91,6 +122,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     }
   }
 
+  /** Set globally ignored endpoints from config */
   @Override
   public void configure(WebSecurity web) {
     final WebSecurity.IgnoredRequestConfigurer ignoredRequestConfigurer = web.ignoring();

--- a/sip-security/src/main/resources/sip-security-default-config.yaml
+++ b/sip-security/src/main/resources/sip-security-default-config.yaml
@@ -48,9 +48,3 @@ sip.security:
       key-store-type: ${sip.security.ssl.server.key-store-type}
       key-alias: ${sip.security.ssl.server.key-alias}
       key-password: ${sip.security.ssl.server.key-password}
-
-# Disabling Springs security autoconfiguration which applies base auth by default if no other authentication is provided.
-spring:
-  autoconfigure:
-    exclude[0]: org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
-    exclude[1]: org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration

--- a/sip-security/src/test/resources/application-filter-test.yaml
+++ b/sip-security/src/test/resources/application-filter-test.yaml
@@ -3,17 +3,17 @@ sip.security:
     enabled: true
     disable-csrf: true
     auth-providers:
-      - classname: de.ikor.sip.foundation.security.authentication.providers.basic.SIPBasicAuthenticationProvider
+      - classname: de.ikor.sip.foundation.security.authentication.basic.SIPBasicAuthAuthenticationProvider
         ignored-endpoints:
           - /actuator/health
           - /actuator/env
         validation:
-          classname: de.ikor.sip.foundation.security.authentication.providers.basic.SIPBasicAuthFileValidator
+          classname: de.ikor.sip.foundation.security.authentication.basic.SIPBasicAuthFileValidator
           file-path: classpath:/basic-auth-users.json
-      - classname: de.ikor.sip.foundation.security.authentication.providers.x509.SIPX509AuthenticationProvider
+      - classname: de.ikor.sip.foundation.security.authentication.x509.SIPX509AuthenticationProvider
         ignored-endpoints:
           - /favicon.ico
           - /actuator/env
         validation:
-          classname: de.ikor.sip.foundation.security.authentication.validators.SIPAlwaysAllowValidator
+          classname: de.ikor.sip.foundation.security.authentication.common.validators.SIPAlwaysAllowValidator
           file-path: classpath://client-certs.acl

--- a/sip-security/src/test/resources/application.yaml
+++ b/sip-security/src/test/resources/application.yaml
@@ -10,17 +10,17 @@ sip.security:
     enabled: true
     disable-csrf: true
     auth-providers:
-      - classname: de.ikor.sip.foundation.security.authentication.providers.basic.SIPBasicAuthenticationProvider
+      - classname: de.ikor.sip.foundation.security.authentication.basic.SIPBasicAuthAuthenticationProvider
         ignored-endpoints:
           - /actuator/health
           - /actuator/env
         validation:
-          classname: de.ikor.sip.foundation.security.authentication.providers.basic.SIPBasicAuthFileValidator
+          classname: de.ikor.sip.foundation.security.authentication.basic.SIPBasicAuthFileValidator
           file-path: classpath:/basic-auth-users.json
-      - classname: de.ikor.sip.foundation.security.authentication.providers.x509.SIPX509AuthenticationProvider
+      - classname: de.ikor.sip.foundation.security.authentication.x509.SIPX509AuthenticationProvider
         ignored-endpoints:
           - /favicon.ico
           - /actuator/env
         validation:
-          classname: de.ikor.sip.foundation.security.authentication.validators.SIPAlwaysAllowValidator
+          classname: de.ikor.sip.foundation.security.authentication.common.validators.SIPAlwaysAllowValidator
           file-path: classpath://client-certs.acl


### PR DESCRIPTION
# Description

Override of the default Spring security configuration doesn't work through config (Spring autoloading process is already underway at that point). 

Other way to override default security is to extend WebSecurityConfigurerAdapter. SIP already has SecurityConfig which extends it but it had a condition on authentification being enabled. 

I've changed it so our security config is unconditionally loaded if SIP security is loaded since authentication isn't the only facet of SIP security.


Fixes # 983

## Type of change

Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [X] Adapter working without any Auth providers and default Spring security is disabled
- [X] Adapter working properly with Auth providers defined

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing (regression) unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
