### PR TITLE
- Adding parent relative path to adapter's root pom

### DIFF
--- a/changelogs/bugfix/format-adapter-pom-relativePath.json
+++ b/changelogs/bugfix/format-adapter-pom-relativePath.json
@@ -1,0 +1,5 @@
+{
+  "author": "vladiIkor",
+  "pullrequestId": 75,
+  "message": "Adding relative path of adapter's parent in root pom"
+}

--- a/sip-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/sip-archetype/src/main/resources/archetype-resources/pom.xml
@@ -7,6 +7,7 @@
         <groupId>de.ikor.sip.foundation</groupId>
         <artifactId>sip-framework</artifactId>
         <version>${archetypeVersion}</version>
+        <relativePath/>
     </parent>
 
     <groupId>${groupId}</groupId>


### PR DESCRIPTION
# Description

Added relative path to archetype to consolidate pom structure.

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Doing mvn install on newly generated adapter cause warn message to appear, saying that pom is mal-formatted.
After this fix, warning should be gone


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing (regression) unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules