### PR TITLE
Adding groupId into application module pom

### DIFF
--- a/changelogs/bugfix/adding-groupId-to-achetype-application-modul.json
+++ b/changelogs/bugfix/adding-groupId-to-achetype-application-modul.json
@@ -1,5 +1,5 @@
 {
   "author": "vladiIkor",
-  "pullrequestId": 77,
+  "pullrequestId": 79,
   "message": "GroupId is added to archetype generated application/pom.xml"
 }

--- a/changelogs/bugfix/adding-groupId-to-achetype-application-modul.json
+++ b/changelogs/bugfix/adding-groupId-to-achetype-application-modul.json
@@ -1,0 +1,5 @@
+{
+  "author": "vladiIkor",
+  "pullrequestId": 77,
+  "message": "GroupId is added to archetype generated application/pom.xml"
+}

--- a/sip-archetype/src/main/resources/archetype-resources/__rootArtifactId__-application/pom.xml
+++ b/sip-archetype/src/main/resources/archetype-resources/__rootArtifactId__-application/pom.xml
@@ -10,6 +10,7 @@
         <relativePath/>
     </parent>
 
+    <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
     <name>${projectName}</name>
     <version>${version}</version>


### PR DESCRIPTION
# Description

Adding a missing groupId into application/pom.xml. 


## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?

Generate adapter from archetype. Do mvn install. Check m2 folder. All adapter modules should be deployed under corresponding folder (according to provided groupId)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing (regression) unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
