### PR TITLE
Mapping down health Http status to 200

### DIFF
--- a/changelogs/feature/health-down-http-status-200.json
+++ b/changelogs/feature/health-down-http-status-200.json
@@ -1,0 +1,5 @@
+{
+  "author": "vladiIkor",
+  "pullrequestId": "80",
+  "message": "Changing http response status to 200 by default if adapter health results with DOWN"
+}

--- a/sip-core/src/main/resources/sip-core-default-config.yaml
+++ b/sip-core/src/main/resources/sip-core-default-config.yaml
@@ -23,8 +23,17 @@ sip.core:
         fixed-delay: 900000
         initial-delay: 5000
 
-management.endpoint.health.show-details: always
-management.endpoints.web.exposure.include: health,info,metrics,loggers,prometheus,adapter-routes
+management:
+  info:
+    camel:
+      enabled: false
+  endpoints.web.exposure.include: health,info,metrics,loggers,prometheus,adapter-routes
+  endpoint:
+    health:
+      show-details: always
+      status:
+        http-mapping:
+          down: 200
 
 springdoc:
   show-actuator: true
@@ -32,8 +41,3 @@ springdoc:
   swagger-ui:
     path: /swagger-ui.html
     disable-swagger-default-url: true
-
-management:
-  info:
-    camel:
-      enabled: false


### PR DESCRIPTION
# Description

Http response status is set to 200 when actuator/health returns DOWN

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Start adapter and stop one route. Inspect actuator/health endpoint. Check returned status code. 200 is expected


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing (regression) unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
