### PR TITLE
- Removing duplicated maven-enforcer-plugin.version property from pom

### DIFF
--- a/changelogs/bugfix/remove-double-maven-enforcer-version-from-pom.json
+++ b/changelogs/bugfix/remove-double-maven-enforcer-version-from-pom.json
@@ -1,0 +1,5 @@
+{
+  "author": "vladiIkor",
+  "pullrequestId": 90,
+  "message": "Remove maven-enforcer-plugin.version duplicate from framework pom properties"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,6 @@
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
         <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
         <fmt-maven-plugin.version>2.13</fmt-maven-plugin.version>
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>


### PR DESCRIPTION
# Description

Removing duplicated maven enforcer plugin version property from pom

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Change should not affect the project anyhow. Run mvn install to confirm that nothing is broken.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing (regression) unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
