### PR TITLE
- Move camel servlet context config to core docs

### DIFF
--- a/changelogs/bugfix/move-camel-servlet-context-config-to-core.json
+++ b/changelogs/bugfix/move-camel-servlet-context-config-to-core.json
@@ -1,0 +1,5 @@
+{
+  "author": "vladiIkor",
+  "pullrequestId": 95,
+  "message": "Camel servlet context path configured on core level to"
+}

--- a/changelogs/bugfix/move-camel-servlet-context-config-to-core.json
+++ b/changelogs/bugfix/move-camel-servlet-context-config-to-core.json
@@ -1,5 +1,5 @@
 {
   "author": "vladiIkor",
   "pullrequestId": 95,
-  "message": "Camel servlet context path configured on core level to"
+  "message": "camel.servlet.mapping.context-path configured on core level"
 }

--- a/sip-archetype/src/main/resources/archetype-resources/__rootArtifactId__-application/src/main/resources/application.yaml
+++ b/sip-archetype/src/main/resources/archetype-resources/__rootArtifactId__-application/src/main/resources/application.yaml
@@ -1,10 +1,3 @@
-camel:
-  component:
-    servlet:
-      mapping:
-        context-path: /adapter/*
-
-
 # SIP Security configuration
 # This configuration represents the template to use for configuring security. If security is not needed, all
 # configuration properties below under sip.security can be deleted.

--- a/sip-core/src/main/resources/sip-core-default-config.yaml
+++ b/sip-core/src/main/resources/sip-core-default-config.yaml
@@ -41,3 +41,9 @@ springdoc:
   swagger-ui:
     path: /swagger-ui.html
     disable-swagger-default-url: true
+
+#context path for adapter routes
+camel:
+  servlet:
+    mapping:
+      context-path: /adapter/*


### PR DESCRIPTION
# Description

Moving camel.servlet.mapping.context-path to core

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?

Start adapter with http incoming route. Make sure there is no camel.servlet.mapping.context-path set on adapter level.
Check if endpoint is available under /adapter/{endpoint-path}

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing (regression) unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
