### PR TITLE
Fix unchecked and deprecated warnings during maven install

### DIFF
--- a/changelogs/bugfix/key-value-pairs-in-logs.json
+++ b/changelogs/bugfix/key-value-pairs-in-logs.json
@@ -1,0 +1,5 @@
+{
+  "author": "Nemikor",
+  "pullrequestId": 91,
+  "message": "Replace log messages with key value pairs so they are able to be translated"
+}

--- a/changelogs/bugfix/remove-sip-static-context.json
+++ b/changelogs/bugfix/remove-sip-static-context.json
@@ -1,0 +1,5 @@
+{
+  "author": "Nemikor",
+  "pullrequestId": "104",
+  "message": "Refactor SIPTranslateMessageService so that it no longer requires SIPStaticSpringContext to register itself"
+}

--- a/changelogs/bugfix/unchecked_and_deprecated_warnings.json
+++ b/changelogs/bugfix/unchecked_and_deprecated_warnings.json
@@ -1,0 +1,5 @@
+{
+  "author": "Nemikor",
+  "pullrequestId": 110,
+  "message": "Refactor code which causes unchecked or deprecated warnings"
+}

--- a/changelogs/feature/key-value-pairs-in-logs.json
+++ b/changelogs/feature/key-value-pairs-in-logs.json
@@ -1,5 +1,0 @@
-{
-  "author": "Nemikor",
-  "pullrequestId": 91,
-  "message": "Replace log messages with key value pairs from translation service"
-}

--- a/changelogs/feature/remove-sip-static-context.json
+++ b/changelogs/feature/remove-sip-static-context.json
@@ -1,5 +1,0 @@
-{
-  "author": "Nemikor",
-  "pullrequestId": "104",
-  "message": "Remove SIPStaticSpringContext and update SIPTranslateMessageService"
-}

--- a/changelogs/feature/unchecked_and_deprecated_warnings.json
+++ b/changelogs/feature/unchecked_and_deprecated_warnings.json
@@ -1,0 +1,5 @@
+{
+  "author": "Nemikor",
+  "pullrequestId": 110,
+  "message": "Fix code which causes unchecked or deprecated warnings"
+}

--- a/changelogs/feature/unchecked_and_deprecated_warnings.json
+++ b/changelogs/feature/unchecked_and_deprecated_warnings.json
@@ -1,5 +1,0 @@
-{
-  "author": "Nemikor",
-  "pullrequestId": 110,
-  "message": "Fix code which causes unchecked or deprecated warnings"
-}

--- a/pom.xml
+++ b/pom.xml
@@ -351,6 +351,14 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven-compiler-plugin.version}</version>
                     <configuration>
+                        <compilerArgs>
+                            <arg>
+                                -Xlint:deprecation
+                            </arg>
+                            <arg>
+                                -Xlint:unchecked
+                            </arg>
+                        </compilerArgs>
                         <source>${java.version}</source>
                         <target>${java.version}</target>
                         <annotationProcessorPaths>

--- a/pom.xml
+++ b/pom.xml
@@ -351,14 +351,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven-compiler-plugin.version}</version>
                     <configuration>
-                        <compilerArgs>
-                            <arg>
-                                -Xlint:deprecation
-                            </arg>
-                            <arg>
-                                -Xlint:unchecked
-                            </arg>
-                        </compilerArgs>
+                        <compilerArgument>-Xlint:all</compilerArgument>
                         <source>${java.version}</source>
                         <target>${java.version}</target>
                         <annotationProcessorPaths>

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/ftp/FtpHealthConsumers.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/ftp/FtpHealthConsumers.java
@@ -26,7 +26,7 @@ public class FtpHealthConsumers {
     try {
       noopSucceeded = fileOps.sendNoop();
     } catch (Exception e) {
-      logger.debug("Failed to sendNoop to {}: {}", endpoint, e);
+      logger.debug("Failed to sendNoop to {}: {}", endpoint, e.getMessage());
     }
 
     if (!noopSucceeded && (fileOps.connect(endpoint.getConfiguration(), null))) {

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/routes/AdapterInfoContributor.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/routes/AdapterInfoContributor.java
@@ -33,7 +33,7 @@ public class AdapterInfoContributor implements InfoContributor {
   @Override
   public void contribute(Info.Builder builder) {
     @SuppressWarnings("unchecked")
-    Map<String, Object> buildInfo = (LinkedHashMap<String, Object>) builder.build().get(BUILD_KEY);
+    Map<String, Object> buildInfo = (LinkedHashMap<String, Object>) builder.build().get(BUILD_KEY, LinkedHashMap.class);
 
     if (buildInfo != null) {
       collectAdapterInfo(buildInfo);

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/routes/AdapterInfoContributor.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/routes/AdapterInfoContributor.java
@@ -33,7 +33,7 @@ public class AdapterInfoContributor implements InfoContributor {
   @Override
   public void contribute(Info.Builder builder) {
     @SuppressWarnings("unchecked")
-    Map<String, Object> buildInfo = (LinkedHashMap<String, Object>) builder.build().get(BUILD_KEY, LinkedHashMap.class);
+    Map<String, Object> buildInfo = builder.build().get(BUILD_KEY, LinkedHashMap.class);
 
     if (buildInfo != null) {
       collectAdapterInfo(buildInfo);

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/routes/AdapterInfoContributor.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/routes/AdapterInfoContributor.java
@@ -32,6 +32,7 @@ public class AdapterInfoContributor implements InfoContributor {
    */
   @Override
   public void contribute(Info.Builder builder) {
+    @SuppressWarnings("unchecked")
     Map<String, Object> buildInfo = (LinkedHashMap<String, Object>) builder.build().get(BUILD_KEY);
 
     if (buildInfo != null) {

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/routes/MarkdownFilesContributor.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/routes/MarkdownFilesContributor.java
@@ -30,6 +30,8 @@ public class MarkdownFilesContributor implements InfoContributor {
   @SneakyThrows
   @Override
   public void contribute(Info.Builder builder) {
+
+    @SuppressWarnings("unchecked")
     Map<String, Object> buildInfo = (LinkedHashMap<String, Object>) builder.build().get(BUILD_KEY);
 
     if (buildInfo == null) {

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/routes/MarkdownFilesContributor.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/routes/MarkdownFilesContributor.java
@@ -32,7 +32,7 @@ public class MarkdownFilesContributor implements InfoContributor {
   public void contribute(Info.Builder builder) {
 
     @SuppressWarnings("unchecked")
-    Map<String, Object> buildInfo = (LinkedHashMap<String, Object>) builder.build().get(BUILD_KEY);
+    Map<String, Object> buildInfo = (LinkedHashMap<String, Object>) builder.build().get(BUILD_KEY, LinkedHashMap.class);
 
     if (buildInfo == null) {
       buildInfo = new LinkedHashMap<>();

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/routes/MarkdownFilesContributor.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/routes/MarkdownFilesContributor.java
@@ -32,7 +32,7 @@ public class MarkdownFilesContributor implements InfoContributor {
   public void contribute(Info.Builder builder) {
 
     @SuppressWarnings("unchecked")
-    Map<String, Object> buildInfo = (LinkedHashMap<String, Object>) builder.build().get(BUILD_KEY, LinkedHashMap.class);
+    Map<String, Object> buildInfo = builder.build().get(BUILD_KEY, LinkedHashMap.class);
 
     if (buildInfo == null) {
       buildInfo = new LinkedHashMap<>();

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/translate/logging/EventLogCloner.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/translate/logging/EventLogCloner.java
@@ -18,6 +18,7 @@ public interface EventLogCloner {
    * @return {@link LoggingEvent}
    */
   @Mapping(target = "message", ignore = true)
+  @Mapping(target = "mdc", ignore = true)
   @Mapping(
       source = "throwableProxy",
       target = "throwableProxy",

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/translate/logging/SIPPatternLayoutEncoder.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/translate/logging/SIPPatternLayoutEncoder.java
@@ -1,16 +1,16 @@
 package de.ikor.sip.foundation.core.translate.logging;
 
-import ch.qos.logback.core.Layout;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.pattern.PatternLayoutEncoderBase;
-import org.slf4j.event.LoggingEvent;
 
 /**
  * Extends PatternLayoutEncoderBase in order to enhance it with message translation feature by
  * featuring {@link TranslateMessageLayout} .
  *
- * @param <E> event type
+
  */
-public class SIPPatternLayoutEncoder<E> extends PatternLayoutEncoderBase<E> {
+public class SIPPatternLayoutEncoder extends PatternLayoutEncoderBase<ILoggingEvent> {
 
   @Override
   public void start() {
@@ -19,7 +19,7 @@ public class SIPPatternLayoutEncoder<E> extends PatternLayoutEncoderBase<E> {
     patternLayout.setPattern(getPattern());
     patternLayout.setContext(context);
     patternLayout.start();
-    this.layout = (Layout<E>) patternLayout;
+    this.layout = patternLayout;
     super.start();
   }
 }

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/translate/logging/SIPPatternLayoutEncoder.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/translate/logging/SIPPatternLayoutEncoder.java
@@ -7,8 +7,6 @@ import ch.qos.logback.core.pattern.PatternLayoutEncoderBase;
 /**
  * Extends PatternLayoutEncoderBase in order to enhance it with message translation feature by
  * featuring {@link TranslateMessageLayout} .
- *
-
  */
 public class SIPPatternLayoutEncoder extends PatternLayoutEncoderBase<ILoggingEvent> {
 

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/translate/logging/TranslateMessageLayout.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/translate/logging/TranslateMessageLayout.java
@@ -14,6 +14,7 @@ import org.mapstruct.factory.Mappers;
  *
  * @param <E> event type
  */
+@SuppressWarnings("java:S2326")
 public class TranslateMessageLayout<E> extends PatternLayout implements Layout<ILoggingEvent> {
   private SIPTranslateMessageService messageService;
 

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/health/ftp/FtpHealthConsumersTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/health/ftp/FtpHealthConsumersTest.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 class FtpHealthConsumersTest {
 
   private ListAppender<ILoggingEvent> listAppender;
-  private RemoteFileOperations<Object> fileOps;
+  private RemoteFileOperations fileOps;
   private RemoteFileEndpoint<?> endpoint;
   private RemoteFileConfiguration configuration;
   private List<ILoggingEvent> logsList;
@@ -59,7 +59,7 @@ class FtpHealthConsumersTest {
   void Given_SendNoopThrowsException_When_noopConsumer_Then_failMessage() {
     // arrange
     when(endpoint.getConfiguration()).thenReturn(null);
-    when(fileOps.sendNoop()).thenThrow(new RuntimeException());
+    when(fileOps.sendNoop()).thenThrow(new RuntimeException("msg"));
     when(fileOps.connect(any(), any())).thenReturn(true);
 
     // act

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/routes/AdapterInfoContributorTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/routes/AdapterInfoContributorTest.java
@@ -40,7 +40,8 @@ class AdapterInfoContributorTest {
 
     // assert
     @SuppressWarnings("unchecked")
-    LinkedHashMap<String, Object> target = (LinkedHashMap<String, Object>) builder.build().get(BUILD_KEY, LinkedHashMap.class);
+    LinkedHashMap<String, Object> target =
+        (LinkedHashMap<String, Object>) builder.build().get(BUILD_KEY, LinkedHashMap.class);
     assertThat(target)
         .hasSize(3)
         .containsEntry(ADAPTER_NAME_DETAILS_KEY, ADAPTER_NAME_TEST)

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/routes/AdapterInfoContributorTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/routes/AdapterInfoContributorTest.java
@@ -58,7 +58,9 @@ class AdapterInfoContributorTest {
     subject.contribute(builder);
 
     // assert
-    assertThat(builder.build().get(BUILD_KEY, LinkedHashMap.class)).isNull();
+    @SuppressWarnings("unchecked")
+    LinkedHashMap<Object, Object> target = builder.build().get(BUILD_KEY, LinkedHashMap.class);
+    assertThat(target).isNull();
   }
 
   private LinkedHashMap<String, Object> createBuildInfo() {

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/routes/AdapterInfoContributorTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/routes/AdapterInfoContributorTest.java
@@ -39,7 +39,9 @@ class AdapterInfoContributorTest {
     subject.contribute(builder);
 
     // assert
-    assertThat((LinkedHashMap<String, Object>) builder.build().get(BUILD_KEY))
+    @SuppressWarnings("unchecked")
+    LinkedHashMap<String, Object> target = (LinkedHashMap<String, Object>) builder.build().get(BUILD_KEY, LinkedHashMap.class);
+    assertThat(target)
         .hasSize(3)
         .containsEntry(ADAPTER_NAME_DETAILS_KEY, ADAPTER_NAME_TEST)
         .containsEntry(ADAPTER_VERSION_DETAILS_KEY, ADAPTER_VERSION_TEST)

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/routes/AdapterInfoContributorTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/routes/AdapterInfoContributorTest.java
@@ -58,7 +58,7 @@ class AdapterInfoContributorTest {
     subject.contribute(builder);
 
     // assert
-    assertThat(builder.build().get(BUILD_KEY)).isNull();
+    assertThat(builder.build().get(BUILD_KEY, LinkedHashMap.class)).isNull();
   }
 
   private LinkedHashMap<String, Object> createBuildInfo() {

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/routes/MarkdownFilesContributorTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/routes/MarkdownFilesContributorTest.java
@@ -61,7 +61,7 @@ class MarkdownFilesContributorTest {
     // assert
     @SuppressWarnings("unchecked")
     LinkedHashMap<String, Object> buildInfoResult =
-        (LinkedHashMap<String, Object>) builder.build().get(BUILD_KEY);
+        (LinkedHashMap<String, Object>) builder.build().get(BUILD_KEY, LinkedHashMap.class);
     @SuppressWarnings("unchecked")
     List<MarkdownObject> resultFiles = (List<MarkdownObject>) buildInfoResult.get(FILES_KEY);
 

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/routes/MarkdownFilesContributorTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/routes/MarkdownFilesContributorTest.java
@@ -59,8 +59,10 @@ class MarkdownFilesContributorTest {
     Files.deleteIfExists(directory);
 
     // assert
+    @SuppressWarnings("unchecked")
     LinkedHashMap<String, Object> buildInfoResult =
         (LinkedHashMap<String, Object>) builder.build().get(BUILD_KEY);
+    @SuppressWarnings("unchecked")
     List<MarkdownObject> resultFiles = (List<MarkdownObject>) buildInfoResult.get(FILES_KEY);
 
     assertThat(buildInfoResult).hasSize(1);

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/proxies/ProcessorProxyTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/proxies/ProcessorProxyTest.java
@@ -71,6 +71,7 @@ class ProcessorProxyTest {
 
     when(exchange.getPattern()).thenReturn(ExchangePattern.InOut);
 
+    @SuppressWarnings("unchecked")
     UnaryOperator<Exchange> mockFunction = mock(UnaryOperator.class);
     when(mockFunction.apply(exchange)).thenReturn(exchange);
 
@@ -134,6 +135,7 @@ class ProcessorProxyTest {
     // arrange
     putProxyInTestMode();
     when(exchange.getPattern()).thenReturn(ExchangePattern.InOut);
+    @SuppressWarnings("unchecked")
     UnaryOperator<Exchange> mockFunction = mock(UnaryOperator.class);
     when(mockFunction.apply(exchange)).thenReturn(exchange);
 


### PR DESCRIPTION
# Description

Update the code which causes unchecked or deprecated warning.

## Type of change

- [x] Refactoring

# How Has This Been Tested?

Check whether maven install generates any warning.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing (regression) unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
