### PR TITLE
SIP-1236|fixing sonar issues

### DIFF
--- a/changelogs/bugfix/fix-sonar-security.json
+++ b/changelogs/bugfix/fix-sonar-security.json
@@ -1,0 +1,5 @@
+{
+  "author": "LetoBukarica",
+  "pullrequestId": "125",
+  "message": "Fixed security issue on the tracing configuration controller."
+}

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/trace/TrafficTracerController.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/trace/TrafficTracerController.java
@@ -46,7 +46,7 @@ public class TrafficTracerController {
       description = "Sets the value of a parameter in ExchangeFormatter for Trace logs")
   public boolean changeParameter(
       @Parameter(name = "parameter", description = "Parameter name") @PathVariable String parameter,
-      @Parameter(name = "value", description = "Parameter value") @RequestBody Object value) {
+      @Parameter(name = "value", description = "Parameter value") @RequestBody String value) {
     DefaultExchangeFormatterConfigurer configurer = new DefaultExchangeFormatterConfigurer();
     return configurer.configure(
         camelContext, camelContext.getTracer().getExchangeFormatter(), parameter, value, true);

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/trace/TrafficTracerControllerTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/trace/TrafficTracerControllerTest.java
@@ -33,7 +33,7 @@ class TrafficTracerControllerTest {
     when(camelContext.getTypeConverter().mandatoryConvertTo(any(), any())).thenReturn(true);
 
     // assert
-    assertThat(endpointSubject.changeParameter("showexchangeid", true)).isTrue();
+    assertThat(endpointSubject.changeParameter("showexchangeid", "true")).isTrue();
   }
 
   @Test
@@ -43,7 +43,7 @@ class TrafficTracerControllerTest {
     when(camelContext.getTracer().getExchangeFormatter()).thenReturn(new SIPExchangeFormatter());
 
     // assert
-    assertThat(endpointSubject.changeParameter("doesnotexist", true)).isFalse();
+    assertThat(endpointSubject.changeParameter("doesnotexist", "true")).isFalse();
   }
 
   @Test


### PR DESCRIPTION
# Description

There is a potential security issue with our dynamic tracing configuration. We take a value from the REST endpoint and just pass it to Camel. Sonar has an issue with this, as it should.


## Type of change

Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Done a manual regression test on the actuator tracing endpoints
- [X] Checked the tracing output
- [X] Run automatized tests

* SIP Framework version(s): 2.1.0


# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing (regression) unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
