### PR TITLE
Use string escape utils for user input

### DIFF
--- a/changelogs/bugfix/fix-sonar-security-log-issue.json
+++ b/changelogs/bugfix/fix-sonar-security-log-issue.json
@@ -1,0 +1,5 @@
+{
+  "author": "Nemikor",
+  "pullrequestId": "127",
+  "message": "Fixed security issue on the tracing configuration controller for logging user input."
+}

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/trace/TrafficTracerController.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/trace/TrafficTracerController.java
@@ -6,7 +6,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.apache.camel.CamelContext;
 import org.apache.camel.support.processor.DefaultExchangeFormatterConfigurer;
-import org.apache.camel.util.StringHelper;
+import org.apache.commons.text.StringEscapeUtils;
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -48,7 +48,7 @@ public class TrafficTracerController {
   public boolean changeParameter(
       @Parameter(name = "parameter", description = "Parameter name") @PathVariable String parameter,
       @Parameter(name = "value", description = "Parameter value") @RequestBody String value) {
-    String configParamValue = StringHelper.sanitize(value);
+    String configParamValue = StringEscapeUtils.escapeJava(value);
     DefaultExchangeFormatterConfigurer configurer = new DefaultExchangeFormatterConfigurer();
     return configurer.configure(
         camelContext,


### PR DESCRIPTION
# Description

Resolve sonar issue for logging unsafe user input in Traffic tracer controller

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SIP Framework version(s):
* Other configuration:

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing (regression) unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
