### PR TITLE
SIP-1236|update nexus staging plugin to avoid old xstream version issues

### DIFF
--- a/changelogs/bugfix/update-nexus-maven-plugin.json
+++ b/changelogs/bugfix/update-nexus-maven-plugin.json
@@ -1,0 +1,5 @@
+{
+  "author": "LetoBukarica",
+  "pullrequestId": "130",
+  "message": "Updated nexus-staging-maven-plugin and removed hardcoded XStream dependency management.."
+}

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <fmt-maven-plugin.version>2.13</fmt-maven-plugin.version>
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
-        <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+        <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
         <maven-core.version>3.8.6</maven-core.version>
         <maven-project-dependecies.version>3.8.4</maven-project-dependecies.version>
         <maven-plugin-annotations.version>3.6.1</maven-plugin-annotations.version>
@@ -552,18 +552,6 @@
                         <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                         <autoReleaseAfterClose>true</autoReleaseAfterClose>
                     </configuration>
-                    <dependencies>
-                        <!--
-                        TODO:
-                            Remove after OSSRH-66257, NEXUS-26993 are fixed,
-                            possibly via https://github.com/sonatype/nexus-maven-plugins/pull/91
-                        -->
-                        <dependency>
-                            <groupId>com.thoughtworks.xstream</groupId>
-                            <artifactId>xstream</artifactId>
-                            <version>1.4.19</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
 
             </plugins>

--- a/sip-starter-parent/pom.xml
+++ b/sip-starter-parent/pom.xml
@@ -69,7 +69,7 @@
     <properties>
         <sip-framework.version>2.1.1-SNAPSHOT</sip-framework.version>
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
-        <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+        <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
     </properties>
 
     <dependencies>
@@ -145,18 +145,6 @@
                         <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                         <autoReleaseAfterClose>true</autoReleaseAfterClose>
                     </configuration>
-                    <dependencies>
-                        <!--
-                        TODO:
-                            Remove after OSSRH-66257, NEXUS-26993 are fixed,
-                            possibly via https://github.com/sonatype/nexus-maven-plugins/pull/91
-                        -->
-                        <dependency>
-                            <groupId>com.thoughtworks.xstream</groupId>
-                            <artifactId>xstream</artifactId>
-                            <version>1.4.19</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
# Description

We bumped XStream library version as part of the regular maintenance process. It makes issues with our maven staging plugin (that deploys to maven central). Us pointing to specific XStream version was because that plugin wasn't maintained for 5 years, but now it's updated and those issues seem to be fixed (https://issues.sonatype.org/browse/NEXUS-31214, https://issues.sonatype.org/browse/NEXUS-31301, https://issues.sonatype.org/browse/NEXUS-26993 and so on)

Fixes # (issue)
https://github.com/IKOR-GmbH/sip-framework/runs/7613688889?check_suite_focus=true

## Type of change

Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Set-up local Nexus repository via docker (sonatype/nexus:oss), reproduced the error and fixed it.


# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings

