### PR TITLE
Prevent NPE in test kit validation

### DIFF
--- a/changelogs/bugfix/refactor-test-validation.json
+++ b/changelogs/bugfix/refactor-test-validation.json
@@ -1,0 +1,5 @@
+{
+  "author": "Nemikor",
+  "pullrequestId": "132",
+  "message": "Prevent NPE when actual response is null, allow validation for empty body and add validation details for mocks."
+}

--- a/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/util/RegexUtil.java
+++ b/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/util/RegexUtil.java
@@ -25,21 +25,20 @@ public class RegexUtil {
    * @return true if string matches the pattern, otherwise false
    */
   public static boolean compare(String expected, String actual) {
-    if (areBothEmpty(actual, expected)) {
+    if (areBothBlank(actual, expected)) {
       return true;
-    } else if (areBothDefined(actual, expected)) {
-      String expectedPattern = reformatEscapeCharacter(expected);
-      return Pattern.compile(expectedPattern).matcher(Objects.requireNonNull(actual)).find();
-    } else {
+    } else if (isOneBlank(actual, expected)) {
       return false;
     }
+    String expectedPattern = reformatEscapeCharacter(expected);
+    return Pattern.compile(expectedPattern).matcher(Objects.requireNonNull(actual)).find();
   }
 
   /**
    * Replaces escape characters
    *
    * @param str - String to be reformated
-   * @return String - either null if param null or reformated param string
+   * @return String - either null if param null or reformatted param string
    */
   public static String reformatEscapeCharacter(String str) {
     if (str == null) {
@@ -56,11 +55,11 @@ public class RegexUtil {
     return pattern;
   }
 
-  private static boolean areBothDefined(String actual, String expected) {
-    return isNotEmpty(actual) && isNotEmpty(expected);
+  private static boolean isOneBlank(String actual, String expected) {
+    return isBlank(actual) || isBlank(expected);
   }
 
-  private static boolean areBothEmpty(String actual, String expected) {
+  private static boolean areBothBlank(String actual, String expected) {
     return isBlank(expected) && isBlank(actual);
   }
 }

--- a/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/util/RegexUtil.java
+++ b/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/util/RegexUtil.java
@@ -26,12 +26,14 @@ public class RegexUtil {
    * @return true if string matches the pattern, otherwise false
    */
   public static boolean compare(String expected, String actual) {
-    boolean result = false;
-    if (areExpectedAndActualEmpty(actual, expected)) {
+    boolean result;
+    if (areBothEmpty(actual, expected)) {
       result = true;
-    } else if (shouldDoComparison(actual, expected)) {
+    } else if (areBothDefined(actual, expected)) {
       String expectedPattern = reformatEscapeCharacter(expected);
       result = Pattern.compile(expectedPattern).matcher(Objects.requireNonNull(actual)).find();
+    } else {
+      result = false;
     }
     return result;
   }
@@ -57,13 +59,11 @@ public class RegexUtil {
     return pattern;
   }
 
-  private static boolean shouldDoComparison(String actual, String expected) {
-    // avoid NPE in regex compare and matching any empty string
-    return actual != null && isNotEmpty(expected);
+  private static boolean areBothDefined(String actual, String expected) {
+    return isNotEmpty(actual) && isNotEmpty(expected);
   }
 
-  private static boolean areExpectedAndActualEmpty(String actual, String expected) {
-    // match if actual body is empty or null when expected is defined as empty
+  private static boolean areBothEmpty(String actual, String expected) {
     return isEmpty(expected) && isEmpty(actual);
   }
 }

--- a/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/util/RegexUtil.java
+++ b/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/util/RegexUtil.java
@@ -1,5 +1,8 @@
 package de.ikor.sip.foundation.testkit.util;
 
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -23,8 +26,14 @@ public class RegexUtil {
    * @return true if string matches the pattern, otherwise false
    */
   public static boolean compare(String expected, String actual) {
-    String expectedPattern = reformatEscapeCharacter(expected);
-    return Pattern.compile(expectedPattern).matcher(Objects.requireNonNull(actual)).find();
+    boolean result = false;
+    if (areExpectedAndActualEmpty(actual, expected)) {
+      result = true;
+    } else if (shouldDoComparison(actual, expected)) {
+      String expectedPattern = reformatEscapeCharacter(expected);
+      result = Pattern.compile(expectedPattern).matcher(Objects.requireNonNull(actual)).find();
+    }
+    return result;
   }
 
   /**
@@ -46,5 +55,15 @@ public class RegexUtil {
               escCharacter.equals("\\$") ? "\\\\" + escCharacter : "\\" + escCharacter);
     }
     return pattern;
+  }
+
+  private static boolean shouldDoComparison(String actual, String expected) {
+    // avoid NPE in regex compare and matching any empty string
+    return actual != null && isNotEmpty(expected);
+  }
+
+  private static boolean areExpectedAndActualEmpty(String actual, String expected) {
+    // match if actual body is empty or null when expected is defined as empty
+    return isEmpty(expected) && isEmpty(actual);
   }
 }

--- a/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/util/RegexUtil.java
+++ b/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/util/RegexUtil.java
@@ -22,7 +22,7 @@ public class RegexUtil {
    *
    * @param expected used to create a regex pattern
    * @param actual string that should be matched
-   * @return true if string matches the pattern, otherwise false
+   * @return true if string matches the pattern or if both are blank, otherwise false
    */
   public static boolean compare(String expected, String actual) {
     if (areBothBlank(actual, expected)) {

--- a/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/util/RegexUtil.java
+++ b/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/util/RegexUtil.java
@@ -1,7 +1,6 @@
 package de.ikor.sip.foundation.testkit.util;
 
-import static org.apache.commons.lang3.StringUtils.isEmpty;
-import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static org.apache.commons.lang3.StringUtils.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -26,16 +25,14 @@ public class RegexUtil {
    * @return true if string matches the pattern, otherwise false
    */
   public static boolean compare(String expected, String actual) {
-    boolean result;
     if (areBothEmpty(actual, expected)) {
-      result = true;
+      return true;
     } else if (areBothDefined(actual, expected)) {
       String expectedPattern = reformatEscapeCharacter(expected);
-      result = Pattern.compile(expectedPattern).matcher(Objects.requireNonNull(actual)).find();
+      return Pattern.compile(expectedPattern).matcher(Objects.requireNonNull(actual)).find();
     } else {
-      result = false;
+      return false;
     }
-    return result;
   }
 
   /**
@@ -64,6 +61,6 @@ public class RegexUtil {
   }
 
   private static boolean areBothEmpty(String actual, String expected) {
-    return isEmpty(expected) && isEmpty(actual);
+    return isBlank(expected) && isBlank(actual);
   }
 }

--- a/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/workflow/reporting/model/MockReport.java
+++ b/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/workflow/reporting/model/MockReport.java
@@ -3,6 +3,8 @@ package de.ikor.sip.foundation.testkit.workflow.reporting.model;
 import static de.ikor.sip.foundation.testkit.util.SIPExchangeHelper.mapToMessageProperties;
 
 import de.ikor.sip.foundation.testkit.configurationproperties.models.MessageProperties;
+import de.ikor.sip.foundation.testkit.workflow.thenphase.result.ValidationResult;
+import java.util.List;
 import java.util.Map;
 import lombok.Data;
 import lombok.experimental.Accessors;
@@ -18,6 +20,7 @@ public class MockReport {
   private Exchange actual;
   private MessageProperties actualMessage;
   private Map<String, Object> validatedHeaders;
+  private List<ValidationResult> validationResults;
 
   public MockReport setExpected(Exchange expected) {
     this.expected = expected;

--- a/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/workflow/thenphase/validator/impl/CamelBodyValidator.java
+++ b/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/workflow/thenphase/validator/impl/CamelBodyValidator.java
@@ -1,14 +1,14 @@
 package de.ikor.sip.foundation.testkit.workflow.thenphase.validator.impl;
 
-import static org.apache.camel.support.MessageHelper.extractBodyAsString;
-import static org.apache.camel.support.MessageHelper.resetStreamCache;
-
 import de.ikor.sip.foundation.testkit.util.RegexUtil;
 import de.ikor.sip.foundation.testkit.workflow.thenphase.result.ValidationResult;
 import de.ikor.sip.foundation.testkit.workflow.thenphase.validator.ExchangeValidator;
 import lombok.AllArgsConstructor;
 import org.apache.camel.Exchange;
 import org.springframework.stereotype.Component;
+
+import static org.apache.camel.support.MessageHelper.extractBodyAsString;
+import static org.apache.camel.support.MessageHelper.resetStreamCache;
 
 /** Validator for body of a request in Camel */
 @Component
@@ -25,10 +25,14 @@ public class CamelBodyValidator implements ExchangeValidator {
   @Override
   public ValidationResult execute(Exchange actualResult, Exchange expectedResponse) {
     resetStreamCache(actualResult.getMessage());
-    boolean result =
-        RegexUtil.compare(
-            extractBodyAsString(expectedResponse.getMessage()),
-            extractBodyAsString(actualResult.getMessage()));
+    String actual = extractBodyAsString(actualResult.getMessage());
+    String expected = extractBodyAsString(expectedResponse.getMessage());
+    boolean result = false;
+    if (actual == null && "".equals(expected)) {
+      result = true;
+    } else if (actual != null && !"".equals(expected)) { // avoid NPE in regex compare and any match empty string
+      result = RegexUtil.compare(expected, actual);
+    }
     return new ValidationResult(
         result, result ? "Body validation successful" : "Body validation unsuccessful");
   }

--- a/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/workflow/thenphase/validator/impl/CamelBodyValidator.java
+++ b/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/workflow/thenphase/validator/impl/CamelBodyValidator.java
@@ -28,14 +28,24 @@ public class CamelBodyValidator implements ExchangeValidator {
     String actual = extractBodyAsString(actualResult.getMessage());
     String expected = extractBodyAsString(expectedResponse.getMessage());
     boolean result = false;
-    if (actual == null && expected.isEmpty()) {
+    if (isNoBodyExpected(actual, expected)) {
       result = true;
-    } else if (actual != null
-        && !expected.isEmpty()) { // avoid NPE in regex compare and matching any empty string
+    } else if (isBodyExpected(actual, expected)) {
       result = RegexUtil.compare(expected, actual);
     }
     return new ValidationResult(
         result, result ? "Body validation successful" : "Body validation unsuccessful");
+  }
+
+  private boolean isBodyExpected(String actual, String expected) {
+    // avoid NPE in regex compare and matching any empty string
+    return actual != null && !expected.isEmpty();
+  }
+
+  private boolean isNoBodyExpected(String actual, String expected) {
+    // match if actual body is empty or null when expected is defined as empty
+    return (actual == null && expected.isEmpty())
+        || (actual != null && actual.isEmpty() && expected.isEmpty());
   }
 
   @Override

--- a/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/workflow/thenphase/validator/impl/CamelBodyValidator.java
+++ b/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/workflow/thenphase/validator/impl/CamelBodyValidator.java
@@ -25,27 +25,12 @@ public class CamelBodyValidator implements ExchangeValidator {
   @Override
   public ValidationResult execute(Exchange actualResult, Exchange expectedResponse) {
     resetStreamCache(actualResult.getMessage());
-    String actual = extractBodyAsString(actualResult.getMessage());
-    String expected = extractBodyAsString(expectedResponse.getMessage());
-    boolean result = false;
-    if (isNoBodyExpected(actual, expected)) {
-      result = true;
-    } else if (isBodyExpected(actual, expected)) {
-      result = RegexUtil.compare(expected, actual);
-    }
+    boolean result =
+        RegexUtil.compare(
+            extractBodyAsString(expectedResponse.getMessage()),
+            extractBodyAsString(actualResult.getMessage()));
     return new ValidationResult(
         result, result ? "Body validation successful" : "Body validation unsuccessful");
-  }
-
-  private boolean isBodyExpected(String actual, String expected) {
-    // avoid NPE in regex compare and matching any empty string
-    return actual != null && !expected.isEmpty();
-  }
-
-  private boolean isNoBodyExpected(String actual, String expected) {
-    // match if actual body is empty or null when expected is defined as empty
-    return (actual == null && expected.isEmpty())
-        || (actual != null && actual.isEmpty() && expected.isEmpty());
   }
 
   @Override

--- a/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/workflow/thenphase/validator/impl/CamelBodyValidator.java
+++ b/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/workflow/thenphase/validator/impl/CamelBodyValidator.java
@@ -1,14 +1,14 @@
 package de.ikor.sip.foundation.testkit.workflow.thenphase.validator.impl;
 
+import static org.apache.camel.support.MessageHelper.extractBodyAsString;
+import static org.apache.camel.support.MessageHelper.resetStreamCache;
+
 import de.ikor.sip.foundation.testkit.util.RegexUtil;
 import de.ikor.sip.foundation.testkit.workflow.thenphase.result.ValidationResult;
 import de.ikor.sip.foundation.testkit.workflow.thenphase.validator.ExchangeValidator;
 import lombok.AllArgsConstructor;
 import org.apache.camel.Exchange;
 import org.springframework.stereotype.Component;
-
-import static org.apache.camel.support.MessageHelper.extractBodyAsString;
-import static org.apache.camel.support.MessageHelper.resetStreamCache;
 
 /** Validator for body of a request in Camel */
 @Component
@@ -28,9 +28,10 @@ public class CamelBodyValidator implements ExchangeValidator {
     String actual = extractBodyAsString(actualResult.getMessage());
     String expected = extractBodyAsString(expectedResponse.getMessage());
     boolean result = false;
-    if (actual == null && "".equals(expected)) {
+    if (actual == null && expected.isEmpty()) {
       result = true;
-    } else if (actual != null && !"".equals(expected)) { // avoid NPE in regex compare and any match empty string
+    } else if (actual != null
+        && !expected.isEmpty()) { // avoid NPE in regex compare and matching any empty string
       result = RegexUtil.compare(expected, actual);
     }
     return new ValidationResult(

--- a/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/workflow/thenphase/validator/impl/CamelTestCaseValidator.java
+++ b/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/workflow/thenphase/validator/impl/CamelTestCaseValidator.java
@@ -64,6 +64,7 @@ public class CamelTestCaseValidator implements TestCaseValidator {
             : EndpointValidationOutcome.UNSUCCESSFUL);
     mockReport.setValidatedHeaders(
         extractValidatedHeaders(mockReport.getActual(), mockReport.getExpected()));
+    mockReport.setValidationResults(endpointValidationResultList);
   }
 
   private boolean isNotSuccess(MockReport mockReport) {

--- a/sip-test-kit/src/main/resources/templates/report-template.ftl
+++ b/sip-test-kit/src/main/resources/templates/report-template.ftl
@@ -16,9 +16,7 @@
   </#if>
   <#if report.adapterReport.responseMessage?has_content>
     Actual response:
-    <#if report.adapterReport.responseMessage.body??>
-      Body: ${report.adapterReport.responseMessage.body}
-    </#if>
+      Body: <#if report.adapterReport.responseMessage.body??>${report.adapterReport.responseMessage.body}</#if>
     <#if report.adapterReport.validatedHeaders?has_content>
       Validated headers:
       <#list report.adapterReport.validatedHeaders?keys as key>
@@ -49,6 +47,12 @@
       <#list report.mockReports?keys as key>
       Endpoint "${key}" was mocked
       Validation ${report.mockReports[key].validated}
+      <#if report.mockReports[key].validationResults?has_content>
+      Validation details:
+        <#list report.mockReports[key].validationResults as validationResult>
+        ${validationResult.message}
+        </#list>
+      </#if>
       <#if report.mockReports[key].actualMessage?has_content>
       Received:
        Body: <#if report.mockReports[key].actualMessage.body??>${report.mockReports[key].actualMessage.body}</#if>

--- a/sip-test-kit/src/main/resources/templates/report-template.ftl
+++ b/sip-test-kit/src/main/resources/templates/report-template.ftl
@@ -51,7 +51,7 @@
       Validation ${report.mockReports[key].validated}
       <#if report.mockReports[key].actualMessage?has_content>
       Received:
-       Body: ${report.mockReports[key].actualMessage.body}
+       Body: <#if report.mockReports[key].actualMessage.body??>${report.mockReports[key].actualMessage.body}</#if>
       </#if>
        <#if report.mockReports[key].validatedHeaders?has_content>
        Headers:
@@ -61,7 +61,7 @@
        </#if>
       <#if report.mockReports[key].expectedMessage?has_content>
       Expected:
-       Body: ${report.mockReports[key].expectedMessage.body}
+       Body: <#if report.mockReports[key].expectedMessage.body??>${report.mockReports[key].expectedMessage.body}</#if>
       <#if report.mockReports[key].expectedMessage.headers?has_content>
        Headers:
         <#list report.mockReports[key].expectedMessage.headers?keys as mkey>

--- a/sip-test-kit/src/main/resources/translations/sip-test-kit-messages.properties
+++ b/sip-test-kit/src/main/resources/translations/sip-test-kit-messages.properties
@@ -1,5 +1,5 @@
 sip.testkit.exception.testcaseinit_{}=Error occurred during initialization of test case: {0}
-sip.testkit.workflow.testrunerror_{}=An error occurred while performing test {}
+sip.testkit.workflow.testrunerror_{}=An error occurred while performing test {0}
 sip.testkit.workflow.startcamelrequest=Starting CAMEL request execution...
 sip.testkit.util.nonserializablevalue_{}=Value for header {0} could not be serialized
 sip.testkit.workflow.whenphase.routeinvoker.soap.request_{}=SIP Test Kit send request: {0}

--- a/sip-test-kit/src/test/java/de/ikor/sip/foundation/testkit/workflow/thenphase/validator/impl/CamelBodyValidatorTest.java
+++ b/sip-test-kit/src/test/java/de/ikor/sip/foundation/testkit/workflow/thenphase/validator/impl/CamelBodyValidatorTest.java
@@ -15,64 +15,107 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class CamelBodyValidatorTest {
 
-  CamelBodyValidator bodyValidator;
+  private static final ValidationResult VALIDATION_RESULT_SUCCESSFUL =
+      new ValidationResult(true, "Body validation successful");
+  private static final ValidationResult VALIDATION_RESULT_UNSUCCESSFUL =
+      new ValidationResult(false, "Body validation unsuccessful");
+
+  CamelBodyValidator bodyValidatorSubject;
   Exchange result;
   Exchange expected;
   private static final String RESULT = "test";
 
   @BeforeEach
   public void setUp() {
-    bodyValidator = new CamelBodyValidator();
+    bodyValidatorSubject = new CamelBodyValidator();
     result = mock(Exchange.class, RETURNS_DEEP_STUBS);
     expected = mock(Exchange.class, RETURNS_DEEP_STUBS);
   }
 
   @Test
-  void execute_Success() {
+  void When_execute_Expect_Success() {
     Message resultMessage = mock(Message.class);
     Message expectedMessage = mock(Message.class);
     when(result.getMessage()).thenReturn(resultMessage);
     when(expected.getMessage()).thenReturn(expectedMessage);
     when(resultMessage.getBody()).thenReturn(RESULT);
     when(expectedMessage.getBody()).thenReturn(RESULT);
-    ValidationResult validationResultSuccessful =
-        new ValidationResult(true, "Body validation successful");
 
-    ValidationResult validationResult = bodyValidator.execute(result, expected);
+    ValidationResult validationResult = bodyValidatorSubject.execute(result, expected);
 
-    assertEquals(validationResultSuccessful, validationResult);
+    assertEquals(VALIDATION_RESULT_SUCCESSFUL, validationResult);
   }
 
   @Test
-  void execute_Fail() {
+  void When_execute_With_DifferentActualAndExpected_Then_Fail() {
     Message resultMessage = mock(Message.class);
     Message expectedMessage = mock(Message.class);
     when(result.getMessage()).thenReturn(resultMessage);
     when(expected.getMessage()).thenReturn(expectedMessage);
     when(resultMessage.getBody()).thenReturn(RESULT);
     when(expectedMessage.getBody()).thenReturn("null");
-    ValidationResult validationResultUnsuccessful =
-        new ValidationResult(false, "Body validation unsuccessful");
 
-    ValidationResult validationResult = bodyValidator.execute(result, expected);
+    ValidationResult validationResult = bodyValidatorSubject.execute(result, expected);
 
-    assertThat(validationResult).isEqualTo(validationResultUnsuccessful);
+    assertThat(validationResult).isEqualTo(VALIDATION_RESULT_UNSUCCESSFUL);
   }
 
   @Test
-  void isApplicable_Success() {
+  void When_execute_With_NullActual_Then_Fail() {
+    Message resultMessage = mock(Message.class);
+    Message expectedMessage = mock(Message.class);
+    when(result.getMessage()).thenReturn(resultMessage);
+    when(expected.getMessage()).thenReturn(expectedMessage);
+    when(resultMessage.getBody()).thenReturn(null);
+    when(expectedMessage.getBody()).thenReturn("null");
+
+    ValidationResult validationResult = bodyValidatorSubject.execute(result, expected);
+
+    assertThat(validationResult).isEqualTo(VALIDATION_RESULT_UNSUCCESSFUL);
+  }
+
+  @Test
+  void When_execute_With_NullActualAndEmptyExpected_Then_Success() {
+    Message resultMessage = mock(Message.class);
+    Message expectedMessage = mock(Message.class);
+    when(result.getMessage()).thenReturn(resultMessage);
+    when(expected.getMessage()).thenReturn(expectedMessage);
+    when(resultMessage.getBody()).thenReturn(null);
+    when(expectedMessage.getBody()).thenReturn("");
+
+    ValidationResult validationResult = bodyValidatorSubject.execute(result, expected);
+
+    assertThat(validationResult).isEqualTo(VALIDATION_RESULT_SUCCESSFUL);
+  }
+
+  @Test
+  void When_execute_With_EmptyActualAndExpected_Then_Success() {
+    Message resultMessage = mock(Message.class);
+    Message expectedMessage = mock(Message.class);
+    when(result.getMessage()).thenReturn(resultMessage);
+    when(expected.getMessage()).thenReturn(expectedMessage);
+    when(resultMessage.getBody()).thenReturn("");
+    when(expectedMessage.getBody()).thenReturn("");
+
+    ValidationResult validationResult = bodyValidatorSubject.execute(result, expected);
+
+    assertThat(validationResult).isEqualTo(VALIDATION_RESULT_SUCCESSFUL);
+  }
+
+  @Test
+  void When_isApplicable_Expect_Success() {
     when(expected.getMessage().getBody()).thenReturn(RESULT);
 
-    boolean isApplicable = bodyValidator.isApplicable(result, expected);
+    boolean isApplicable = bodyValidatorSubject.isApplicable(result, expected);
 
     assertThat(isApplicable).isTrue();
   }
 
   @Test
-  void isApplicable_MissingBody() {
+  void When_isApplicable_With_MissingBody_Then_Fail() {
     when(expected.getMessage().getBody()).thenReturn(null);
 
-    boolean isApplicable = bodyValidator.isApplicable(result, expected);
+    boolean isApplicable = bodyValidatorSubject.isApplicable(result, expected);
 
     assertThat(isApplicable).isFalse();
   }


### PR DESCRIPTION
# Description

Prevent NPE when actual response is null, allow validation for empty body and extend report for mocks. 

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Test fails if expected is set as empty string, but actual body is not empty
- Test successful if expected and actual are empty
- Test successful if expected is empty, but actual is null
- Endpoint report shows validation details

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing (regression) unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
