### PR TITLE
Fix separate unit tests affecting each other

### DIFF
--- a/changelogs/bugfix/fix-translate-unit-test.json
+++ b/changelogs/bugfix/fix-translate-unit-test.json
@@ -1,0 +1,5 @@
+{
+  "author": "Nemikor",
+  "pullrequestId": "143",
+  "message": "Fix translation unit test which was causing other test to not work correctly."
+}

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/translate/SIPTranslateMessageServiceTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/translate/SIPTranslateMessageServiceTest.java
@@ -8,6 +8,7 @@ import java.util.Locale;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.MessageSource;
+import org.springframework.test.util.ReflectionTestUtils;
 
 class SIPTranslateMessageServiceTest {
 
@@ -54,5 +55,8 @@ class SIPTranslateMessageServiceTest {
 
     // assert
     assertThat(SIPTranslateMessageService.get()).isEqualTo(subject);
+
+    // clear static instance to prevent issues with other tests
+    ReflectionTestUtils.setField(subject, "instance", null);
   }
 }


### PR DESCRIPTION
# Description

Fix issue where unit tests were affecting each other on certain devices.

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SIP Framework version(s):
* Other configuration:

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing (regression) unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
