### PR TITLE
Add RouteInvoker runtime exception

### DIFF
--- a/changelogs/feature/add_testkit_invoker_runtime_exception.json
+++ b/changelogs/feature/add_testkit_invoker_runtime_exception.json
@@ -1,0 +1,5 @@
+{
+  "author": "nikolag-ikor",
+  "pullrequestId": "151",
+  "message": "Add TestKit invoker runtime exception"
+}

--- a/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/workflow/whenphase/routeinvoker/exceptions/RouteInvokerRuntimeException.java
+++ b/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/workflow/whenphase/routeinvoker/exceptions/RouteInvokerRuntimeException.java
@@ -1,0 +1,19 @@
+package de.ikor.sip.foundation.testkit.workflow.whenphase.routeinvoker.exceptions;
+
+/** Exception for impossible invoking first processor in tested route */
+public class RouteInvokerRuntimeException extends RuntimeException {
+
+  public RouteInvokerRuntimeException(String routeInvokerName) {
+    super(String.format("%s could not invoke route under test", routeInvokerName));
+  }
+
+  /**
+   * Method for hiding stack trace in console
+   *
+   * @return Throwable
+   */
+  @Override
+  public synchronized Throwable fillInStackTrace() {
+    return this;
+  }
+}

--- a/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/workflow/whenphase/routeinvoker/impl/FtpRouteInvoker.java
+++ b/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/workflow/whenphase/routeinvoker/impl/FtpRouteInvoker.java
@@ -12,7 +12,6 @@ import java.io.InputStream;
 import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
@@ -27,7 +26,6 @@ import org.springframework.stereotype.Component;
 @Component
 @ConditionalOnClass(FtpComponent.class)
 @RequiredArgsConstructor
-@Slf4j
 public class FtpRouteInvoker implements RouteInvoker {
 
   private final CamelContext camelContext;

--- a/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/workflow/whenphase/routeinvoker/impl/FtpRouteInvoker.java
+++ b/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/workflow/whenphase/routeinvoker/impl/FtpRouteInvoker.java
@@ -5,6 +5,7 @@ import static de.ikor.sip.foundation.testkit.workflow.whenphase.routeinvoker.hea
 import static org.apache.camel.Exchange.*;
 
 import de.ikor.sip.foundation.testkit.workflow.whenphase.routeinvoker.RouteInvoker;
+import de.ikor.sip.foundation.testkit.workflow.whenphase.routeinvoker.exceptions.RouteInvokerRuntimeException;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
@@ -47,7 +48,7 @@ public class FtpRouteInvoker implements RouteInvoker {
     try {
       ftpConsumer.getProcessor().process(ftpExchange);
     } catch (Exception e) {
-      log.error("sip.testkit.workflow.whenphase.routeinvoker.ftp.badrequest");
+      throw new RouteInvokerRuntimeException(this.getClass().getName());
     }
     return Optional.empty();
   }

--- a/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/workflow/whenphase/routeinvoker/impl/JmsRouteInvoker.java
+++ b/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/workflow/whenphase/routeinvoker/impl/JmsRouteInvoker.java
@@ -5,6 +5,7 @@ import static de.ikor.sip.foundation.testkit.workflow.whenphase.routeinvoker.SIP
 
 import de.ikor.sip.foundation.testkit.workflow.whenphase.routeinvoker.RouteInvoker;
 import de.ikor.sip.foundation.testkit.workflow.whenphase.routeinvoker.SIPJmsTextMessage;
+import de.ikor.sip.foundation.testkit.workflow.whenphase.routeinvoker.exceptions.RouteInvokerRuntimeException;
 import de.ikor.sip.foundation.testkit.workflow.whenphase.routeinvoker.exceptions.UnsupportedJmsHeaderException;
 import java.util.Map;
 import java.util.Optional;
@@ -36,7 +37,7 @@ public class JmsRouteInvoker implements RouteInvoker {
     try {
       processor.process(exchange);
     } catch (Exception e) {
-      log.error("sip.testkit.workflow.whenphase.routeinvoker.jms.badrequest");
+      throw new RouteInvokerRuntimeException(this.getClass().getName());
     }
     return Optional.empty();
   }

--- a/sip-test-kit/src/main/resources/translations/sip-test-kit-messages.properties
+++ b/sip-test-kit/src/main/resources/translations/sip-test-kit-messages.properties
@@ -4,7 +4,5 @@ sip.testkit.workflow.startcamelrequest=Starting CAMEL request execution...
 sip.testkit.workflow.whenphase.routeinvoker.soap.request_{}=SIP Test Kit send request: {0}
 sip.testkit.workflow.whenphase.routeinvoker.soap.response_{}=SIP Test Kit receives response: {0}
 sip.testkit.workflow.whenphase.routeinvoker.soap.responseformating=SIP Test Kit response has no body
-sip.testkit.workflow.whenphase.routeinvoker.ftp.badrequest=Sending exchange to ftp consumer route is not possible
-sip.testkit.workflow.whenphase.routeinvoker.jms.badrequest=Sending exchange to jms consumer route is not possible
 sip.testkit.workflow.whenphase.routeinvoker.jms.badheader_{}=Cannot add header {0} to jms message
 sip.testkit.config.nosuspendingroute_{}=Route with route id {0} cannot be suspended

--- a/sip-test-kit/src/test/java/de/ikor/sip/foundation/testkit/workflow/whenphase/routeinvoker/impl/FtpRouteInvokerTest.java
+++ b/sip-test-kit/src/test/java/de/ikor/sip/foundation/testkit/workflow/whenphase/routeinvoker/impl/FtpRouteInvokerTest.java
@@ -3,10 +3,12 @@ package de.ikor.sip.foundation.testkit.workflow.whenphase.routeinvoker.impl;
 import static de.ikor.sip.foundation.testkit.workflow.whenphase.routeinvoker.headers.FtpExchangeHeaders.*;
 import static org.apache.camel.Exchange.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 import de.ikor.sip.foundation.testkit.util.TestKitHelper;
 import de.ikor.sip.foundation.testkit.workflow.givenphase.Mock;
+import de.ikor.sip.foundation.testkit.workflow.whenphase.routeinvoker.exceptions.RouteInvokerRuntimeException;
 import org.apache.camel.*;
 import org.apache.camel.component.file.remote.RemoteFileComponent;
 import org.apache.camel.component.file.remote.RemoteFileConfiguration;
@@ -237,6 +239,16 @@ class FtpRouteInvokerTest {
     assertThat(
             actualFileExchange.getMessage().getHeader(RemoteFileComponent.REMOTE_FILE_INPUT_STREAM))
         .isEqualTo("stream value");
+  }
+
+  @Test
+  void GIVEN_simulatedException_WHEN_invoke_THEN_expectRouteInvokerRuntimeException()
+      throws Exception {
+    // arrange
+    doThrow(Exception.class).when(processor).process(any());
+
+    // act & assert
+    assertThrows(RouteInvokerRuntimeException.class, () -> subject.invoke(inputExchange));
   }
 
   @Test

--- a/sip-test-kit/src/test/java/de/ikor/sip/foundation/testkit/workflow/whenphase/routeinvoker/impl/JmsRouteInvokerTest.java
+++ b/sip-test-kit/src/test/java/de/ikor/sip/foundation/testkit/workflow/whenphase/routeinvoker/impl/JmsRouteInvokerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.*;
 
 import de.ikor.sip.foundation.testkit.util.TestKitHelper;
 import de.ikor.sip.foundation.testkit.workflow.givenphase.Mock;
+import de.ikor.sip.foundation.testkit.workflow.whenphase.routeinvoker.exceptions.RouteInvokerRuntimeException;
 import de.ikor.sip.foundation.testkit.workflow.whenphase.routeinvoker.exceptions.UnsupportedJmsHeaderException;
 import org.apache.camel.Exchange;
 import org.apache.camel.ExtendedCamelContext;
@@ -100,5 +101,15 @@ class JmsRouteInvokerTest {
 
     // act & assert
     assertThrows(UnsupportedJmsHeaderException.class, () -> subject.invoke(inputExchange));
+  }
+
+  @Test
+  void GIVEN_simulatedException_WHEN_invoke_THEN_expectRouteInvokerRuntimeException()
+      throws Exception {
+    // arrange
+    doThrow(Exception.class).when(processor).process(any());
+
+    // act & assert
+    assertThrows(RouteInvokerRuntimeException.class, () -> subject.invoke(inputExchange));
   }
 }


### PR DESCRIPTION
# Description

New Test Kit runtime exception introduced in route invokers. If processor is unable to process test exchange, we would like to get more meaningful exception in test report.


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing (regression) unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
