### PR TITLE
Refactoring onException Connectors level configuration

### DIFF
--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/framework/connectors/OutConnector.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/framework/connectors/OutConnector.java
@@ -15,7 +15,7 @@ public abstract class OutConnector implements Connector {
 
   public abstract void configure(RouteDefinition route);
 
-  public abstract void configureOnConnectorLevel();
+  public void configureOnException() {}
 
   protected OnExceptionDefinition onException(Class<? extends Throwable>... exceptions) {
     OnExceptionDefinition last = null;

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/framework/routers/UseCaseTopologyDefinition.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/framework/routers/UseCaseTopologyDefinition.java
@@ -27,14 +27,12 @@ public class UseCaseTopologyDefinition {
 
   public UseCaseTopologyDefinition to(OutConnector... outConnectors) {
     routeBuilder = CentralRouter.anonymousDummyRouteBuilder();
-    routeDefinition = initBaseRoute(routeBuilder, routeDefinition, "");
+    routeDefinition = initBaseRoute(routeDefinition, "");
     if (outConnectors.length > 1) {
       routeDefinition = appendMulticastDefinition(outConnectors, routeDefinition, "");
     } else {
       OutConnector outConnector = outConnectors[0];
       routeDefinition.to(URI_PREFIX + outConnector.getName());
-      outConnector.setRouteBuilder(routeBuilder);
-      outConnector.configureOnConnectorLevel();
       this.from(outConnector, URI_PREFIX + outConnector.getName(), "");
     }
     routeBuilder.getRouteCollection().getRoutes().add((RouteDefinition) routeDefinition);
@@ -44,7 +42,7 @@ public class UseCaseTopologyDefinition {
 
   private void generateTestRoutes(OutConnector... outConnectors) {
     testingRouteBuilder = CentralRouter.anonymousDummyRouteBuilder();
-    testRouteDefinition = initBaseRoute(testingRouteBuilder, testRouteDefinition, TESTING_SUFFIX);
+    testRouteDefinition = initBaseRoute(testRouteDefinition, TESTING_SUFFIX);
     CentralEndpointsRegister.setState("testing");
     if (outConnectors.length > 1) {
       testRouteDefinition =
@@ -53,8 +51,6 @@ public class UseCaseTopologyDefinition {
       OutConnector outConnector = outConnectors[0];
       testRouteDefinition =
           testRouteDefinition.to(URI_PREFIX + outConnector.getName() + TESTING_SUFFIX);
-      outConnector.setRouteBuilder(testingRouteBuilder);
-      outConnector.configureOnConnectorLevel();
       this.from(outConnector, URI_PREFIX + outConnector.getName(), TESTING_SUFFIX);
     }
     testingRouteBuilder.getRouteCollection().getRoutes().add((RouteDefinition) testRouteDefinition);
@@ -68,9 +64,6 @@ public class UseCaseTopologyDefinition {
         .forEach(
             outConnector -> {
               multicastDefinition.to(URI_PREFIX + outConnector.getName() + suffix);
-              outConnector.setRouteBuilder(
-                  suffix.equals(TESTING_SUFFIX) ? testingRouteBuilder : routeBuilder);
-              outConnector.configureOnConnectorLevel();
               this.from(outConnector, URI_PREFIX + outConnector.getName(), suffix);
             });
     return multicastDefinition.end();
@@ -81,8 +74,7 @@ public class UseCaseTopologyDefinition {
     camelContext.addRoutes(this.testingRouteBuilder);
   }
 
-  private ProcessorDefinition initBaseRoute(
-      RouteBuilder routeBuilder, ProcessorDefinition processorDefinition, String suffix) {
+  private ProcessorDefinition initBaseRoute(ProcessorDefinition processorDefinition, String suffix) {
     String uri = "sipmc:" + useCase + suffix;
     RouteDefinition rd = new RouteDefinition();
 
@@ -96,7 +88,7 @@ public class UseCaseTopologyDefinition {
       OutConnector outConnector, String uri, String routeSuffix) {
     RouteBuilder rb = CentralRouter.anonymousDummyRouteBuilder();
     outConnector.setRouteBuilder(rb);
-    outConnector.configureOnConnectorLevel();
+    outConnector.configureOnException();
     String routeId = CentralRouter.generateRouteId(useCase, outConnector.getName(), routeSuffix);
     RouteDefinition routeDefinition = rb.from(uri + routeSuffix).routeId(routeId);
     outConnector.configure(routeDefinition);

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/routers/OnExceptionConfigurationTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/routers/OnExceptionConfigurationTest.java
@@ -1,0 +1,77 @@
+package de.ikor.sip.foundation.core.framework.routers;
+
+import de.ikor.sip.foundation.core.apps.framework.CentralRouterTestingApplication;
+import de.ikor.sip.foundation.core.framework.connectors.InConnector;
+import de.ikor.sip.foundation.core.framework.connectors.OutConnector;
+import de.ikor.sip.foundation.core.framework.endpoints.InEndpoint;
+import de.ikor.sip.foundation.core.framework.endpoints.OutEndpoint;
+import de.ikor.sip.foundation.core.framework.stubs.*;
+import org.apache.camel.CamelContext;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+import org.apache.camel.test.spring.junit5.MockEndpoints;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Description;
+
+@CamelSpringBootTest
+@SpringBootTest(classes = CentralRouterTestingApplication.class)
+@MockEndpoints("log:message*")
+class OnExceptionConfigurationTest {
+
+    @Autowired(required = false)
+    private TestingCentralRouter routerSubject;
+
+    @Autowired(required = false)
+    private RouteStarter routeStarter;
+
+    @Autowired
+    private ProducerTemplate template;
+
+    @EndpointInject("mock:log:message")
+    private MockEndpoint mock;
+
+    @BeforeEach
+    void setup() {
+        mock.reset();
+    }
+
+    @Test
+    void when_OnExceptionConfiguredOnInConnector_then_ValidateInConnectorOnExceptionExecution() throws Exception {
+        // arrange
+        InConnector inConnector = new OnExceptionInConnector(InEndpoint.instance("direct:inDirect-1", "inDirect-1"));
+        routerSubject.from(inConnector);
+        routeStarter.buildRoutes(routerSubject);
+
+        mock.expectedBodiesReceived("InConnectorException");
+        mock.expectedMessageCount(1);
+
+        // act
+        template.sendBody("direct:inDirect-1", "input body");
+
+        // assert
+        mock.assertIsSatisfied();
+    }
+
+    @Test
+    void when_OnExceptionConfiguredOnOutConnector_then_ValidateOutConnectorOnExceptionExecution() throws Exception {
+        // arrange
+        InConnector inConnector = SimpleInConnector.withUri("direct:inDirect-2");
+        OutConnector outConnector = new OnExceptionOutConnector(OutEndpoint.instance("direct:outDirect", "outDirect-2"));
+        routerSubject.from(inConnector).to(outConnector).build();
+        routeStarter.buildRoutes(routerSubject);
+
+        mock.expectedBodiesReceived("OutConnectorException");
+        mock.expectedMessageCount(1);
+
+        // act
+        template.sendBody("direct:inDirect-2", "input body");
+
+        // assert
+        mock.assertIsSatisfied();
+    }
+}

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/routers/OnExceptionConfigurationTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/routers/OnExceptionConfigurationTest.java
@@ -11,6 +11,7 @@ import org.apache.camel.EndpointInject;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+import org.apache.camel.test.spring.junit5.DisableJmx;
 import org.apache.camel.test.spring.junit5.MockEndpoints;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,6 +23,7 @@ import org.springframework.test.annotation.DirtiesContext;
 @CamelSpringBootTest
 @SpringBootTest(classes = CentralRouterTestingApplication.class)
 @DirtiesContext
+@DisableJmx(false)
 @MockEndpoints("log:message*")
 class OnExceptionConfigurationTest {
 

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/routers/OnExceptionConfigurationTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/routers/OnExceptionConfigurationTest.java
@@ -17,9 +17,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Description;
+import org.springframework.test.annotation.DirtiesContext;
 
 @CamelSpringBootTest
 @SpringBootTest(classes = CentralRouterTestingApplication.class)
+@DirtiesContext
 @MockEndpoints("log:message*")
 class OnExceptionConfigurationTest {
 

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/stubs/AppendStringOutConnector.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/stubs/AppendStringOutConnector.java
@@ -10,7 +10,4 @@ public class AppendStringOutConnector extends OutConnector {
         exchange ->
             exchange.getMessage().setBody(exchange.getMessage().getBody(String.class) + "-append"));
   }
-
-  @Override
-  public void configureOnConnectorLevel() {}
 }

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/stubs/ComplexOutConnector.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/stubs/ComplexOutConnector.java
@@ -33,9 +33,6 @@ public class ComplexOutConnector extends OutConnector {
         .to(OutEndpoint.instance(DIRECT_COMPLEX_MCAST_2_URI, "complex-mcast-2"));
   }
 
-  @Override
-  public void configureOnConnectorLevel() {}
-
   private AggregationStrategy aggregationStrategy() {
     return new GroupedBodyAggregationStrategy();
   }

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/stubs/OnExceptionInConnector.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/stubs/OnExceptionInConnector.java
@@ -1,0 +1,38 @@
+package de.ikor.sip.foundation.core.framework.stubs;
+
+import de.ikor.sip.foundation.core.framework.connectors.InConnector;
+import de.ikor.sip.foundation.core.framework.endpoints.InEndpoint;
+
+public class OnExceptionInConnector extends InConnector {
+
+    private final InEndpoint inEndpoint;
+
+    public OnExceptionInConnector(InEndpoint inEndpoint) {
+        this.inEndpoint = inEndpoint;
+    }
+
+    @Override
+    public String getName() {
+        return "OnExceptionInConnector";
+    }
+
+    @Override
+    public void configure() {
+        from(inEndpoint)
+                .log("lets cause DummyException in InConnector")
+                .process(exchange -> {
+                    throw new TestingDummyException("fake exception");
+                });
+    }
+
+    @Override
+    public void configureOnException() {
+        onException(TestingDummyException.class)
+                .handled(true)
+                .log("DummyException happened, InConnector onException handler is invoked!")
+                .process(exchange -> {
+                    exchange.getMessage().setBody("InConnectorException");
+                })
+                .to("log:message");
+    }
+}

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/stubs/OnExceptionOutConnector.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/stubs/OnExceptionOutConnector.java
@@ -1,0 +1,35 @@
+package de.ikor.sip.foundation.core.framework.stubs;
+
+import de.ikor.sip.foundation.core.framework.connectors.OutConnector;
+import de.ikor.sip.foundation.core.framework.endpoints.OutEndpoint;
+import org.apache.camel.model.RouteDefinition;
+
+public class OnExceptionOutConnector extends OutConnector {
+
+    private final OutEndpoint outEndpoint;
+
+    public OnExceptionOutConnector(OutEndpoint outEndpoint) {
+        this.outEndpoint = outEndpoint;
+    }
+
+    @Override
+    public void configure(RouteDefinition route) {
+        route
+            .log("lets cause DummyException in OutConnector")
+            .process(exchange -> {
+                throw new TestingDummyException("fake exception");
+            })
+            .to(outEndpoint.getEndpointUri());
+    }
+
+    @Override
+    public void configureOnException() {
+        onException(TestingDummyException.class)
+                .handled(true)
+                .log("DummyException happened, OutConnector onException handler is invoked!")
+                .process(exchange -> {
+                    exchange.getMessage().setBody("OutConnectorException");
+                })
+                .to("log:message");
+    }
+}

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/stubs/SimpleInConnector.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/stubs/SimpleInConnector.java
@@ -22,9 +22,6 @@ public class SimpleInConnector extends InConnector {
     from(ep);
   }
 
-  @Override
-  public void configureOnException() {}
-
   public String getName() {
     return name;
   }

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/stubs/SimpleOutConnector.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/stubs/SimpleOutConnector.java
@@ -25,7 +25,4 @@ public class SimpleOutConnector extends TestingOutConnector {
         .to(OutEndpoint.instance(uri, endpointId))
         .id("log-message-endpoint");
   }
-
-  @Override
-  public void configureOnConnectorLevel() {}
 }

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/stubs/SleepingOutConnector.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/stubs/SleepingOutConnector.java
@@ -24,7 +24,4 @@ public class SleepingOutConnector extends TestingOutConnector {
         .to(OutEndpoint.instance(uri, endpointId))
         .id("log-message-endpoint");
   }
-
-  @Override
-  public void configureOnConnectorLevel() {}
 }

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/stubs/TestingDummyException.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/stubs/TestingDummyException.java
@@ -1,0 +1,8 @@
+package de.ikor.sip.foundation.core.framework.stubs;
+
+public class TestingDummyException extends Exception {
+
+    public TestingDummyException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
# Description

Remove onException configurations from internal sipmc-direct route. Add 2 integration tests with onException configuration on InConnector and OutConnector level

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing (regression) unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
