### PR TITLE
SIP-1312|added different spelling of Apache licence

### DIFF
--- a/.github/workflows/check-licenses.sh
+++ b/.github/workflows/check-licenses.sh
@@ -26,6 +26,7 @@ while read line; do
       [[ $line == *"(The Apache License, Version 2.0)"* ]] ||
       [[ $line == *"(Apache 2)"* ]] ||
       [[ $line == *"(Apache 2.0)"* ]] ||
+      [[ $line == *"(Apache-2.0)"* ]] ||
       [[ $line == *"(BSD 2-Clause License)"* ]] ||
       [[ $line == *"(BSD-2-Clause)"* ]] ||
       [[ $line == *"(BSD License 3)"* ]] ||


### PR DESCRIPTION
# Description

Updated the license that's needed for the new version of the Snappy library.

