### PR TITLE
Fix/sip 1352 rest dsl restructure

### DIFF
--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/framework/connectors/InConnector.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/framework/connectors/InConnector.java
@@ -33,13 +33,14 @@ public abstract class InConnector implements Connector {
 
   protected RouteDefinition from(RestDefinition restDefinition) {
     restDefinition.to("direct:rest-" + restInEndpoint.getUri());
+    routeBuilder.getRestCollection().getRests().add(restDefinition);
     return routeBuilder.from("direct:rest-" + restInEndpoint.getUri());
   }
 
   protected RestDefinition rest(String uri, String id) {
     routeBuilder = getRouteBuilderInstance();
-    restInEndpoint = RestInEndpoint.instance(uri, id, routeBuilder);
-    return restInEndpoint.rest();
+    restInEndpoint = RestInEndpoint.instance(uri, id);
+    return restInEndpoint.definition();
   }
 
   protected OnExceptionDefinition onException(Class<? extends Throwable>... exceptions) {

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/framework/connectors/InConnector.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/framework/connectors/InConnector.java
@@ -14,7 +14,6 @@ import org.apache.camel.model.rest.RestDefinition;
 
 public abstract class InConnector implements Connector {
   @Getter private RouteBuilder routeBuilder;
-  private RestInEndpoint restInEndpoint;
   private InEndpoint inEndpoint;
   // TODO: Use different mechanism to detect this
   @Getter @Setter private Boolean registeredInCamel = false;
@@ -32,14 +31,15 @@ public abstract class InConnector implements Connector {
   }
 
   protected RouteDefinition from(RestDefinition restDefinition) {
-    restDefinition.to("direct:rest-" + restInEndpoint.getUri());
+    restDefinition.to("direct:rest-" + inEndpoint.getUri());
     routeBuilder.getRestCollection().getRests().add(restDefinition);
-    return routeBuilder.from("direct:rest-" + restInEndpoint.getUri());
+    return routeBuilder.from("direct:rest-" + inEndpoint.getUri());
   }
 
   protected RestDefinition rest(String uri, String id) {
     routeBuilder = getRouteBuilderInstance();
-    restInEndpoint = RestInEndpoint.instance(uri, id);
+    RestInEndpoint restInEndpoint = RestInEndpoint.instance(uri, id);
+    inEndpoint = restInEndpoint;
     return restInEndpoint.definition();
   }
 

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/framework/endpoints/CentralEndpointsRegister.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/framework/endpoints/CentralEndpointsRegister.java
@@ -81,8 +81,7 @@ public class CentralEndpointsRegister {
 
   private static RestInEndpoint toTestEndpoint(RestInEndpoint restInEndpoint) {
     return new RestInEndpoint(
-        restInEndpoint.getUri() + TestingRoutesUtil.TESTING_SUFFIX,
-        restInEndpoint.getId());
+        restInEndpoint.getUri() + TestingRoutesUtil.TESTING_SUFFIX, restInEndpoint.getId());
   }
 
   private static String modifyUriForTestRoute(String uri) {

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/framework/endpoints/CentralEndpointsRegister.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/framework/endpoints/CentralEndpointsRegister.java
@@ -82,8 +82,7 @@ public class CentralEndpointsRegister {
   private static RestInEndpoint toTestEndpoint(RestInEndpoint restInEndpoint) {
     return new RestInEndpoint(
         restInEndpoint.getUri() + TestingRoutesUtil.TESTING_SUFFIX,
-        restInEndpoint.getId(),
-        restInEndpoint.getRouteBuilder());
+        restInEndpoint.getId());
   }
 
   private static String modifyUriForTestRoute(String uri) {

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/framework/endpoints/OutEndpoint.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/framework/endpoints/OutEndpoint.java
@@ -12,7 +12,7 @@ public class OutEndpoint implements Endpoint {
 
   public static OutEndpoint instance(String uri, String endpointId) {
     CentralEndpointsRegister.put(endpointId, new OutEndpoint(uri, endpointId));
-    return (OutEndpoint) CentralEndpointsRegister.getEndpoint(endpointId);
+    return (OutEndpoint) CentralEndpointsRegister.getOutEndpoint(endpointId);
   }
 
   OutEndpoint(String uri, String endpointId) {

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/framework/endpoints/RestInEndpoint.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/framework/endpoints/RestInEndpoint.java
@@ -4,27 +4,24 @@ import lombok.Getter;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.rest.RestDefinition;
 
-public class RestInEndpoint {
-  @Getter private String uri;
-  @Getter private String id;
-  @Getter private RouteBuilder routeBuilder;
-  private RestDefinition restDefinition;
+public class RestInEndpoint extends InEndpoint{
 
-  public static RestInEndpoint instance(String uri, String id, RouteBuilder routeBuilder) {
+  private final RestDefinition restDefinition;
 
-    RestInEndpoint inEndpoint = new RestInEndpoint(uri, id, routeBuilder);
+  public static RestInEndpoint instance(String uri, String id) {
+
+    RestInEndpoint inEndpoint = new RestInEndpoint(uri, id);
     CentralEndpointsRegister.put(id, inEndpoint);
     return CentralEndpointsRegister.getRestInEndpoint(id);
   }
 
-  protected RestInEndpoint(String uri, String id, RouteBuilder routeBuilder) {
-    this.routeBuilder = routeBuilder;
-    this.restDefinition = this.routeBuilder.rest(uri);
-    this.uri = uri;
-    this.id = id;
+  protected RestInEndpoint(String uri, String id) {
+    super(uri, id);
+    this.restDefinition = new RestDefinition();
+    this.restDefinition.setPath(uri);
   }
 
-  public RestDefinition rest() {
+  public RestDefinition definition() {
     return restDefinition;
   }
 }

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/framework/endpoints/RestInEndpoint.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/framework/endpoints/RestInEndpoint.java
@@ -10,7 +10,7 @@ public class RestInEndpoint extends InEndpoint {
 
     RestInEndpoint inEndpoint = new RestInEndpoint(uri, id);
     CentralEndpointsRegister.put(id, inEndpoint);
-    return CentralEndpointsRegister.getRestInEndpoint(id);
+    return (RestInEndpoint) CentralEndpointsRegister.getInEndpoint(id);
   }
 
   protected RestInEndpoint(String uri, String id) {

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/framework/endpoints/RestInEndpoint.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/framework/endpoints/RestInEndpoint.java
@@ -1,10 +1,8 @@
 package de.ikor.sip.foundation.core.framework.endpoints;
 
-import lombok.Getter;
-import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.rest.RestDefinition;
 
-public class RestInEndpoint extends InEndpoint{
+public class RestInEndpoint extends InEndpoint {
 
   private final RestDefinition restDefinition;
 

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/endpoints/EndpointsIntegrationTests.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/endpoints/EndpointsIntegrationTests.java
@@ -29,7 +29,7 @@ class EndpointsIntegrationTests {
     subject.input(SimpleInConnector.withUri("direct:hey-test")).output(outConnector);
     // assert
 
-    Endpoint registeredEndpoint = CentralEndpointsRegister.getEndpoint("cool-id");
+    Endpoint registeredEndpoint = CentralEndpointsRegister.getOutEndpoint("cool-id");
     Endpoint endpointFromCamelContext = null;
     try {
       endpointFromCamelContext =
@@ -51,7 +51,7 @@ class EndpointsIntegrationTests {
     // assert
 
     CentralEndpointsRegister.putInTestingState();
-    Endpoint registeredEndpoint = CentralEndpointsRegister.getEndpoint("cool-id");
+    Endpoint registeredEndpoint = CentralEndpointsRegister.getOutEndpoint("cool-id");
     Endpoint endpointFromCamelContext = null;
     try {
       endpointFromCamelContext =

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/routers/CentralRouterStructureTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/routers/CentralRouterStructureTest.java
@@ -88,7 +88,7 @@ class CentralRouterStructureTest {
     // act
     routerSubject.input(inConnector).output(outConnector);
     routeStarter.buildRoutes(routerSubject);
-    
+
     // assert
     assertThat(getRoutesFromContext())
         .filteredOn(matchRoutesBasedOnUri(format("sipmc.*%s", routerSubject.getScenario())))

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/routers/OnExceptionConfigurationTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/routers/OnExceptionConfigurationTest.java
@@ -41,10 +41,12 @@ class OnExceptionConfigurationTest {
     mock.reset();
   }
 
-    @Test
-    void when_OnExceptionConfiguredOnInConnector_then_ValidateInConnectorOnExceptionExecution() throws Exception {
+  @Test
+  void when_OnExceptionConfiguredOnInConnector_then_ValidateInConnectorOnExceptionExecution()
+      throws Exception {
     // arrange
-    InConnector inConnector = new OnExceptionInConnector(InEndpoint.instance("direct:inDirect-1", "inDirect-1"));
+    InConnector inConnector =
+        new OnExceptionInConnector(InEndpoint.instance("direct:inDirect-1", "inDirect-1"));
     routerSubject.input(inConnector);
     routeStarter.buildRoutes(routerSubject);
 
@@ -58,11 +60,13 @@ class OnExceptionConfigurationTest {
     mock.assertIsSatisfied();
   }
 
-    @Test
-    void when_OnExceptionConfiguredOnOutConnector_then_ValidateOutConnectorOnExceptionExecution() throws Exception {
+  @Test
+  void when_OnExceptionConfiguredOnOutConnector_then_ValidateOutConnectorOnExceptionExecution()
+      throws Exception {
     // arrange
     InConnector inConnector = SimpleInConnector.withUri("direct:inDirect-2");
-    OutConnector outConnector = new OnExceptionOutConnector(OutEndpoint.instance("direct:outDirect", "outDirect-2"));
+    OutConnector outConnector =
+        new OnExceptionOutConnector(OutEndpoint.instance("direct:outDirect", "outDirect-2"));
     routerSubject.input(inConnector).output(outConnector);
     routeStarter.buildRoutes(routerSubject);
 

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/stubs/RestInConnector.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/stubs/RestInConnector.java
@@ -11,8 +11,6 @@ public class RestInConnector extends InConnector {
   @Override
   public void configure() {
     from(rest("/hello-append", "get-rest").get())
-
-        //    from(RestInEndpoint.instance("/hello-append", "get-rest").definition().get())
         .process(exchange -> exchange.getMessage().setBody("hello rest"));
   }
 

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/stubs/RestInConnector.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/stubs/RestInConnector.java
@@ -1,7 +1,6 @@
 package de.ikor.sip.foundation.core.framework.stubs;
 
 import de.ikor.sip.foundation.core.framework.connectors.InConnector;
-import de.ikor.sip.foundation.core.framework.endpoints.RestInEndpoint;
 
 public class RestInConnector extends InConnector {
   @Override
@@ -13,7 +12,7 @@ public class RestInConnector extends InConnector {
   public void configure() {
     from(rest("/hello-append", "get-rest").get())
 
-//    from(RestInEndpoint.instance("/hello-append", "get-rest").definition().get())
+        //    from(RestInEndpoint.instance("/hello-append", "get-rest").definition().get())
         .process(exchange -> exchange.getMessage().setBody("hello rest"));
   }
 

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/stubs/RestInConnector.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/framework/stubs/RestInConnector.java
@@ -1,6 +1,7 @@
 package de.ikor.sip.foundation.core.framework.stubs;
 
 import de.ikor.sip.foundation.core.framework.connectors.InConnector;
+import de.ikor.sip.foundation.core.framework.endpoints.RestInEndpoint;
 
 public class RestInConnector extends InConnector {
   @Override
@@ -11,6 +12,8 @@ public class RestInConnector extends InConnector {
   @Override
   public void configure() {
     from(rest("/hello-append", "get-rest").get())
+
+//    from(RestInEndpoint.instance("/hello-append", "get-rest").definition().get())
         .process(exchange -> exchange.getMessage().setBody("hello rest"));
   }
 


### PR DESCRIPTION
# Description

Removing routeBuilder from RestInEndpoint as well as smaller cleanup.
Goes to a feature branch so no changelog was added. 



