### PR TITLE
Sip 1427/st id on internal sip routes

### DIFF
--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/AdapterBuilder.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/AdapterBuilder.java
@@ -8,15 +8,16 @@ import de.ikor.sip.foundation.core.declarative.orchestation.Orchestrator;
 import de.ikor.sip.foundation.core.declarative.scenario.IntegrationScenarioConsumerDefinition;
 import de.ikor.sip.foundation.core.declarative.scenario.IntegrationScenarioDefinition;
 import de.ikor.sip.foundation.core.declarative.scenario.IntegrationScenarioProviderDefinition;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import javax.annotation.PostConstruct;
 import lombok.AllArgsConstructor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.RouteDefinition;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Component
 @AllArgsConstructor
@@ -64,6 +65,11 @@ public class AdapterBuilder extends RouteBuilder {
     RouteDefinition camelRoute = from(inboundEndpointDefinition.getInboundEndpoint());
     orchestrateEndpoint(camelRoute, inboundEndpointDefinition);
     camelRoute.to("sipmc:" + scenarioID);
+    String routeId =
+        String.format(
+            "in-%s-%s",
+            inboundEndpointDefinition.getConnectorId(), scenarioID);
+    camelRoute.routeId(routeId);
   }
 
   private void buildOutboundEndpoint(
@@ -72,6 +78,11 @@ public class AdapterBuilder extends RouteBuilder {
     RouteDefinition camelRoute = from("sipmc:" + scenarioID);
     orchestrateEndpoint(camelRoute, outboundEndpointDefinition);
     camelRoute.to(outboundEndpointDefinition.getOutboundEndpoint());
+    String routeId =
+        String.format(
+            "out-%s-%s",
+            outboundEndpointDefinition.getConnectorId(), scenarioID);
+    camelRoute.routeId(routeId);
   }
 
   private void orchestrateEndpoint(

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/endpoints/AnnotatedInboundEndpoint.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/endpoints/AnnotatedInboundEndpoint.java
@@ -24,4 +24,9 @@ public abstract class AnnotatedInboundEndpoint extends AnnotatedEndpoint
     return getDeclarationsRegistry()
         .getScenarioById(inboundEndpointAnnotation.providesToScenario());
   }
+
+  @Override
+  public final String getConnectorId() {
+    return this.getClass().getAnnotation(InboundEndpoint.class).belongsToConnector();
+  }
 }

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/endpoints/AnnotatedOutboundEndpoint.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/endpoints/AnnotatedOutboundEndpoint.java
@@ -22,4 +22,9 @@ public abstract class AnnotatedOutboundEndpoint extends AnnotatedEndpoint
     return getDeclarationsRegistry()
         .getConnectorById(outboundEndpointAnnotation.belongsToConnector());
   }
+
+  @Override
+  public final String getConnectorId() {
+    return this.getClass().getAnnotation(OutboundEndpoint.class).belongsToConnector();
+  }
 }

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/endpoints/InboundEndpointDefinition.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/endpoints/InboundEndpointDefinition.java
@@ -1,6 +1,5 @@
 package de.ikor.sip.foundation.core.declarative.endpoints;
 
-import de.ikor.sip.foundation.core.declarative.connectors.ConnectorDefinition;
 import de.ikor.sip.foundation.core.declarative.orchestation.EndpointOrchestrationInfo;
 import de.ikor.sip.foundation.core.declarative.orchestation.Orchestratable;
 import de.ikor.sip.foundation.core.declarative.scenario.IntegrationScenarioProviderDefinition;
@@ -10,6 +9,4 @@ public interface InboundEndpointDefinition
     extends IntegrationScenarioProviderDefinition, Orchestratable<EndpointOrchestrationInfo> {
 
   EndpointConsumerBuilder getInboundEndpoint();
-
-  ConnectorDefinition getConnector();
 }

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/endpoints/OutboundEndpointDefinition.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/endpoints/OutboundEndpointDefinition.java
@@ -1,6 +1,5 @@
 package de.ikor.sip.foundation.core.declarative.endpoints;
 
-import de.ikor.sip.foundation.core.declarative.connectors.ConnectorDefinition;
 import de.ikor.sip.foundation.core.declarative.orchestation.EndpointOrchestrationInfo;
 import de.ikor.sip.foundation.core.declarative.orchestation.Orchestratable;
 import de.ikor.sip.foundation.core.declarative.scenario.IntegrationScenarioConsumerDefinition;
@@ -10,6 +9,4 @@ public interface OutboundEndpointDefinition
     extends IntegrationScenarioConsumerDefinition, Orchestratable<EndpointOrchestrationInfo> {
 
   EndpointProducerBuilder getOutboundEndpoint();
-
-  ConnectorDefinition getConnector();
 }

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/scenario/IntegrationScenarioConsumerDefinition.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/scenario/IntegrationScenarioConsumerDefinition.java
@@ -1,6 +1,5 @@
 package de.ikor.sip.foundation.core.declarative.scenario;
 
-public interface IntegrationScenarioConsumerDefinition {
-
+public interface IntegrationScenarioConsumerDefinition extends IntegrationScenarioParticipant {
   IntegrationScenarioDefinition getConsumedScenario();
 }

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/scenario/IntegrationScenarioParticipant.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/scenario/IntegrationScenarioParticipant.java
@@ -1,0 +1,10 @@
+package de.ikor.sip.foundation.core.declarative.scenario;
+
+/**
+ * Defines common methods for {@link IntegrationScenarioConsumerDefinition} and {@link
+ * IntegrationScenarioProviderDefinition}
+ */
+public interface IntegrationScenarioParticipant {
+
+  String getConnectorId();
+}

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/scenario/IntegrationScenarioParticipant.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/scenario/IntegrationScenarioParticipant.java
@@ -1,10 +1,14 @@
 package de.ikor.sip.foundation.core.declarative.scenario;
 
+import de.ikor.sip.foundation.core.declarative.connectors.ConnectorDefinition;
+
 /**
  * Defines common methods for {@link IntegrationScenarioConsumerDefinition} and {@link
  * IntegrationScenarioProviderDefinition}
  */
 public interface IntegrationScenarioParticipant {
+
+  ConnectorDefinition getConnector();
 
   String getConnectorId();
 }

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/scenario/IntegrationScenarioProviderDefinition.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/scenario/IntegrationScenarioProviderDefinition.java
@@ -1,6 +1,6 @@
 package de.ikor.sip.foundation.core.declarative.scenario;
 
-public interface IntegrationScenarioProviderDefinition {
+public interface IntegrationScenarioProviderDefinition extends IntegrationScenarioParticipant {
 
   IntegrationScenarioDefinition getProvidedScenario();
 }


### PR DESCRIPTION
# Description
Internal routes receive autogenerated route ids:
in-\<connectorId\>-\<integrationScenarioId\>
out-\<connectorId\>-\<integrationScenarioId\>

## Type of change

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-BasicStructureTest#given_ConnectorAndScenarioDefined_whenAppStarts_RoutesHaveProperId

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing (regression) unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
