### PR TITLE
Fix/sip 1459 adapter routes with metadata

### DIFF
--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/declarative/model/DeclarativeStructureInfo.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/declarative/model/DeclarativeStructureInfo.java
@@ -1,11 +1,15 @@
 package de.ikor.sip.foundation.core.actuator.declarative.model;
 
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Builder
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class DeclarativeStructureInfo {
   private List<ConnectorGroupInfo> connectorgroups;
   private List<IntegrationScenarioInfo> scenarios;

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/routes/AdapterRouteEndpoint.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/routes/AdapterRouteEndpoint.java
@@ -5,6 +5,7 @@ import de.ikor.sip.foundation.core.actuator.routes.annotations.RouteOperationPar
 import de.ikor.sip.foundation.core.declarative.RoutesRegistry;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
@@ -34,7 +35,7 @@ public class AdapterRouteEndpoint {
   private final CamelContext camelContext;
   private final RouteControllerLoggingDecorator routeController;
   private final ManagedCamelContext mbeanContext;
-  private final RoutesRegistry routesRegistry;
+  private final Optional<RoutesRegistry> routesRegistry;
 
   /**
    * Route endpoint
@@ -44,7 +45,7 @@ public class AdapterRouteEndpoint {
   public AdapterRouteEndpoint(
       CamelContext camelContext,
       RouteControllerLoggingDecorator routeController,
-      RoutesRegistry routesRegistry) {
+      Optional<RoutesRegistry> routesRegistry) {
     this.camelContext = camelContext;
     this.routeController = routeController;
     this.routesRegistry = routesRegistry;
@@ -64,7 +65,9 @@ public class AdapterRouteEndpoint {
             route ->
                 new AdapterRouteSummary(
                     getRouteMBean(route.getRouteId()),
-                    routesRegistry.generateRouteInfo(route.getRouteId())))
+                    routesRegistry
+                        .map(registry -> registry.generateRouteInfo(route.getRouteId()))
+                        .orElse(null)))
         .collect(Collectors.toList());
   }
 
@@ -202,7 +205,9 @@ public class AdapterRouteEndpoint {
             route ->
                 new AdapterRouteSummary(
                     getRouteMBean(route.getRouteId()),
-                    routesRegistry.generateRouteInfo(route.getRouteId())));
+                    routesRegistry
+                        .map(registry -> registry.generateRouteInfo(route.getRouteId()))
+                        .orElse(null)));
 
     return adapterRouteSummaryStream.collect(Collectors.toList());
   }

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/routes/AdapterRouteEndpointTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/routes/AdapterRouteEndpointTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.*;
 
 import de.ikor.sip.foundation.core.declarative.RoutesRegistry;
 import java.util.Collections;
+import java.util.Optional;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Route;
@@ -39,7 +40,8 @@ class AdapterRouteEndpointTest {
     ReflectionTestUtils.setField(routeControllerLoggingDecorator, "ctx", camelContext);
     routesRegistry = mock(RoutesRegistry.class, RETURNS_DEEP_STUBS);
     subject =
-        new AdapterRouteEndpoint(camelContext, routeControllerLoggingDecorator, routesRegistry);
+        new AdapterRouteEndpoint(
+            camelContext, routeControllerLoggingDecorator, Optional.of(routesRegistry));
   }
 
   @Test

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/apps/declarative/SimpleAdapter.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/apps/declarative/SimpleAdapter.java
@@ -64,7 +64,8 @@ public class SimpleAdapter {
       connectorId = "appendStaticMessageConsumer",
       belongsToGroup = "SIP2",
       fromScenario = AppendStaticMessageScenario.ID,
-      requestModel = String.class)
+      requestModel = String.class,
+      pathToDocumentationResource = "documents/structure/connectors/genericDescription")
   public class AppendStaticMessageConsumer extends GenericOutboundConnectorBase {
 
     @Override

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/declarative/DeclarativeDefinitionEndpointTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/declarative/DeclarativeDefinitionEndpointTest.java
@@ -51,6 +51,9 @@ class DeclarativeDefinitionEndpointTest {
     // assert
     assertThat(httpResponse.getStatusLine().getStatusCode()).isEqualTo(200);
     assertThat(declarativeStructureInfo.getScenarios()).hasSize(SCENARIOS_IN_TEST_ADAPTER);
+    assertThat(declarativeStructureInfo.getConnectors()).hasSize(CONNECTORS_IN_TEST_ADAPTER);
+    assertThat(declarativeStructureInfo.getConnectorgroups())
+        .hasSize(CONNECTORGROUPS_IN_TEST_ADAPTER);
   }
 
   @Test

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/declarative/DeclarativeDefinitionEndpointTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/declarative/DeclarativeDefinitionEndpointTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.CollectionType;
 import de.ikor.sip.foundation.core.actuator.declarative.model.ConnectorGroupInfo;
 import de.ikor.sip.foundation.core.actuator.declarative.model.ConnectorInfo;
+import de.ikor.sip.foundation.core.actuator.declarative.model.DeclarativeStructureInfo;
 import de.ikor.sip.foundation.core.actuator.declarative.model.IntegrationScenarioInfo;
 import de.ikor.sip.foundation.core.apps.declarative.SimpleAdapter;
 import java.io.IOException;
@@ -32,6 +33,26 @@ class DeclarativeDefinitionEndpointTest {
 
   @LocalServerPort private int localServerPort;
 
+  private final int CONNECTORGROUPS_IN_TEST_ADAPTER = 2;
+  private final int SCENARIOS_IN_TEST_ADAPTER = 2;
+  private final int CONNECTORS_IN_TEST_ADAPTER = 4;
+
+  @Test
+  void when_ActuatorGetAdapterDefinitionInfo_then_RetrieveFullAdapterInfo() throws IOException {
+    // arrange
+    HttpUriRequest request =
+        new HttpGet("http://localhost:" + localServerPort + "/actuator/adapterdefinition");
+
+    // act
+    HttpResponse httpResponse = HttpClientBuilder.create().build().execute(request);
+    DeclarativeStructureInfo declarativeStructureInfo =
+        mapper.readValue(httpResponse.getEntity().getContent(), DeclarativeStructureInfo.class);
+
+    // assert
+    assertThat(httpResponse.getStatusLine().getStatusCode()).isEqualTo(200);
+    assertThat(declarativeStructureInfo.getScenarios()).hasSize(SCENARIOS_IN_TEST_ADAPTER);
+  }
+
   @Test
   void when_ActuatorGetScenarioInfo_then_RetrieveScenarios() throws IOException {
     // arrange
@@ -53,7 +74,7 @@ class DeclarativeDefinitionEndpointTest {
             scenarioInfo ->
                 "Scenario used for testing which appends static message"
                     .equals(scenarioInfo.getScenarioDescription()))
-        .hasSize(2);
+        .hasSize(SCENARIOS_IN_TEST_ADAPTER);
   }
 
   @Test
@@ -81,7 +102,7 @@ class DeclarativeDefinitionEndpointTest {
             connectorGroupInfo ->
                 "Test Documentation for an implicitly created connectorgroup"
                     .equals(connectorGroupInfo.getConnectorGroupDescription()))
-        .hasSize(2);
+        .hasSize(CONNECTORGROUPS_IN_TEST_ADAPTER);
   }
 
   @Test
@@ -105,6 +126,9 @@ class DeclarativeDefinitionEndpointTest {
             connectorInfo ->
                 "Provides messages from direct to AppendStaticMessage scenario"
                     .equals(connectorInfo.getConnectorDescription()))
-        .hasSize(4);
+        .anyMatch(
+            connectorInfo ->
+                "Generic connector description.".equals(connectorInfo.getConnectorDescription()))
+        .hasSize(CONNECTORS_IN_TEST_ADAPTER);
   }
 }

--- a/sip-core/src/test/resources/documents/structure/connectors/genericDescription
+++ b/sip-core/src/test/resources/documents/structure/connectors/genericDescription
@@ -1,0 +1,1 @@
+Generic connector description.


### PR DESCRIPTION
# Description

Fix for the case that the declaration structure is turned off (so RoutesRegistry is optional).
Added 2 test cases (non-default path for docs & root path adapter structure)