### PR TITLE
Add filtering for route summary on actuator endpoint

### DIFF
--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/http/HttpHealthIndicators.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/health/http/HttpHealthIndicators.java
@@ -8,7 +8,6 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Endpoint;
 import org.springframework.boot.actuate.health.Health;
@@ -59,17 +58,6 @@ public class HttpHealthIndicators {
    */
   public static Health urlHealthIndicator(Endpoint endpoint) {
     return urlHealthStatus(endpoint, DEFAULT_HTTP_TIMEOUT);
-  }
-
-  /**
-   * Returns health checking function using custom url along with desired timeout.
-   *
-   * @param url The URL to use when performing the health check
-   * @param timeout the timeout
-   * @return function that checks health of the HTTP endpoint
-   */
-  public static Function<Endpoint, Health> urlHealthIndicator(String url, int timeout) {
-    return endpoint -> urlHealthStatus(endpoint, timeout);
   }
 
   private static Health urlHealthStatus(Endpoint endpoint, int timeout) {

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/routes/AdapterRouteEndpoint.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/routes/AdapterRouteEndpoint.java
@@ -217,8 +217,8 @@ public class AdapterRouteEndpoint {
    * @param ids list of route ids
    * @return list of {@link AdapterRouteSummary} for provided ids
    */
-  @GetMapping("/details")
-  public List<AdapterRouteSummary> details(@RequestParam(value = "ids") List<String> ids) {
+  @GetMapping("/summary")
+  public List<AdapterRouteSummary> summary(@RequestParam(value = "ids") List<String> ids) {
     return filterRoutesSummary(ids);
   }
 

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/routes/AdapterRouteEndpoint.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/routes/AdapterRouteEndpoint.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.CamelContext;
@@ -64,7 +63,7 @@ public class AdapterRouteEndpoint {
   public List<AdapterRouteSummary> routes() {
     return camelContext.getRoutes().stream()
         .map(route -> generateSummary(route.getRouteId()))
-        .collect(Collectors.toList());
+        .toList();
   }
 
   /** Stops all routes */
@@ -199,7 +198,7 @@ public class AdapterRouteEndpoint {
     Stream<AdapterRouteSummary> adapterRouteSummaryStream =
         routeStream.map(route -> generateSummary(route.getRouteId()));
 
-    return adapterRouteSummaryStream.collect(Collectors.toList());
+    return adapterRouteSummaryStream.toList();
   }
 
   private ManagedRouteMBean getRouteMBean(String routeId) {
@@ -223,7 +222,7 @@ public class AdapterRouteEndpoint {
   }
 
   private List<AdapterRouteSummary> filterRoutesSummary(Collection<String> routeIds) {
-    return routeIds.stream().map(this::generateSummary).collect(Collectors.toList());
+    return routeIds.stream().map(this::generateSummary).toList();
   }
 
   private AdapterRouteSummary generateSummary(String routeId) {

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/routes/AdapterRouteEndpoint.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/actuator/routes/AdapterRouteEndpoint.java
@@ -4,6 +4,7 @@ import de.ikor.sip.foundation.core.actuator.routes.annotations.RouteIdParameter;
 import de.ikor.sip.foundation.core.actuator.routes.annotations.RouteOperationParameter;
 import de.ikor.sip.foundation.core.declarative.RoutesRegistry;
 import io.swagger.v3.oas.annotations.Operation;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.server.ResponseStatusException;
 
 /**
@@ -61,13 +63,7 @@ public class AdapterRouteEndpoint {
   @Operation(summary = "Get all routes", description = "Get list of Routes from Camel Context")
   public List<AdapterRouteSummary> routes() {
     return camelContext.getRoutes().stream()
-        .map(
-            route ->
-                new AdapterRouteSummary(
-                    getRouteMBean(route.getRouteId()),
-                    routesRegistry
-                        .map(registry -> registry.generateRouteInfo(route.getRouteId()))
-                        .orElse(null)))
+        .map(route -> generateSummary(route.getRouteId()))
         .collect(Collectors.toList());
   }
 
@@ -201,13 +197,7 @@ public class AdapterRouteEndpoint {
     Stream<Route> routeStream = filterMiddleComponentProducerRoutes(camelContext.getRoutes());
 
     Stream<AdapterRouteSummary> adapterRouteSummaryStream =
-        routeStream.map(
-            route ->
-                new AdapterRouteSummary(
-                    getRouteMBean(route.getRouteId()),
-                    routesRegistry
-                        .map(registry -> registry.generateRouteInfo(route.getRouteId()))
-                        .orElse(null)));
+        routeStream.map(route -> generateSummary(route.getRouteId()));
 
     return adapterRouteSummaryStream.collect(Collectors.toList());
   }
@@ -219,5 +209,26 @@ public class AdapterRouteEndpoint {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND);
     }
     return routeMBean;
+  }
+
+  /**
+   * Get route summary for provided route ids
+   *
+   * @param ids list of route ids
+   * @return list of {@link AdapterRouteSummary} for provided ids
+   */
+  @GetMapping("/details")
+  public List<AdapterRouteSummary> details(@RequestParam(value = "ids") List<String> ids) {
+    return filterRoutesSummary(ids);
+  }
+
+  private List<AdapterRouteSummary> filterRoutesSummary(Collection<String> routeIds) {
+    return routeIds.stream().map(this::generateSummary).collect(Collectors.toList());
+  }
+
+  private AdapterRouteSummary generateSummary(String routeId) {
+    return new AdapterRouteSummary(
+        getRouteMBean(routeId),
+        routesRegistry.map(registry -> registry.generateRouteInfo(routeId)).orElse(null));
   }
 }

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/routes/AdapterRouteEndpointContextTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/routes/AdapterRouteEndpointContextTest.java
@@ -51,14 +51,14 @@ class AdapterRouteEndpointContextTest {
   @Test
   void When_callingFilteredDetails_With_ValidRoute_Then_httpSuccessReceived() throws Exception {
     mvcBean
-        .perform(get("/actuator/adapter-routes/details?ids=" + CoreTestApplication.TEST_ROUTE_ID))
+        .perform(get("/actuator/adapter-routes/summary?ids=" + CoreTestApplication.TEST_ROUTE_ID))
         .andExpect(status().is2xxSuccessful());
   }
 
   @Test
   void When_callingFilteredDetails_With_InvalidRoute_Then_httpSuccessReceived() throws Exception {
     mvcBean
-        .perform(get("/actuator/adapter-routes/details?ids=" + NON_EXISTENT_ROUTE_ID))
+        .perform(get("/actuator/adapter-routes/summary?ids=" + NON_EXISTENT_ROUTE_ID))
         .andExpect(status().isNotFound());
   }
 }

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/routes/AdapterRouteEndpointContextTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/actuator/routes/AdapterRouteEndpointContextTest.java
@@ -47,4 +47,18 @@ class AdapterRouteEndpointContextTest {
         .perform(post("/actuator/adapter-routes/" + NON_EXISTENT_ROUTE_ID + "/reset"))
         .andExpect(status().isNotFound());
   }
+
+  @Test
+  void When_callingFilteredDetails_With_ValidRoute_Then_httpSuccessReceived() throws Exception {
+    mvcBean
+        .perform(get("/actuator/adapter-routes/details?ids=" + CoreTestApplication.TEST_ROUTE_ID))
+        .andExpect(status().is2xxSuccessful());
+  }
+
+  @Test
+  void When_callingFilteredDetails_With_InvalidRoute_Then_httpSuccessReceived() throws Exception {
+    mvcBean
+        .perform(get("/actuator/adapter-routes/details?ids=" + NON_EXISTENT_ROUTE_ID))
+        .andExpect(status().isNotFound());
+  }
 }


### PR DESCRIPTION
# Description

Add filtering for route summary on actuator "/adapter-routes" endpoint
Example: "/adapter-routes/summary?ids=routeId1,routeId2"

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SIP Framework version(s):
* Other configuration:

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing (regression) unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
