### PR TITLE
SIP-1624|updated testkit regex matching

### DIFF
--- a/changelogs/bugfix/testkit_regex_matcher.json
+++ b/changelogs/bugfix/testkit_regex_matcher.json
@@ -1,0 +1,5 @@
+{
+  "author": "vladiIkor",
+  "pullrequestId": "224",
+  "message": "Updated testkit regex matcher to use DOTALL pattern."
+}

--- a/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/util/RegexUtil.java
+++ b/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/util/RegexUtil.java
@@ -35,7 +35,7 @@ public class RegexUtil {
     }
     String expectedPattern = reformatEscapeCharacter(removeCarriageReturns(expected));
     String actualFormatted = removeCarriageReturns(Objects.requireNonNull(actual));
-    return Pattern.compile(expectedPattern).matcher(actualFormatted).find();
+    return Pattern.compile(expectedPattern, Pattern.DOTALL).matcher(actualFormatted).find();
   }
 
   /**


### PR DESCRIPTION
# Description

Our current Regex matcher on testkit validation takes into account new lines (doesn't ignore them). Changed the matcher to Pattern.DOTALL since it better fits our testkit logic.

## Type of change

Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

