### PR TITLE
SIP-1786|fixing format exception

### DIFF
--- a/changelogs/bugfix/fix_orchestration_error_message.json
+++ b/changelogs/bugfix/fix_orchestration_error_message.json
@@ -1,0 +1,5 @@
+{
+  "author": "LetoBukarica",
+  "pullrequestId": "239",
+  "message": "Fixed process orchestration error message exception."
+}

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/AdapterBuilder.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/AdapterBuilder.java
@@ -314,8 +314,9 @@ public class AdapterBuilder extends RouteBuilder {
             .orElseThrow(
                 () ->
                     SIPFrameworkInitializationException.init(
-                        "Composite process '%s' uses a provider class '%' which couldn't be found in the registry. Please check your configuration.",
-                        compositeProcess.getId(), compositeProcess.getProviderDefinition()));
+                        "Composite process '%s' uses a provider scenario '%s' which couldn't be found in the registry. Please check your configuration.",
+                        compositeProcess.getId(),
+                        compositeProcess.getProviderDefinition().getName()));
     final var startingEndpoint =
         StaticEndpointBuilders.direct(
             String.format(
@@ -334,8 +335,8 @@ public class AdapterBuilder extends RouteBuilder {
                       .orElseThrow(
                           () ->
                               SIPFrameworkInitializationException.init(
-                                  "Composite process '%s' uses a consumer class '%' which couldn't be found in the registry. Please check your configuration.",
-                                  compositeProcess.getId(), consumer));
+                                  "Composite process '%s' uses a consumer scenario '%s' which couldn't be found in the registry. Please check your configuration.",
+                                  compositeProcess.getId(), consumer.getName()));
               var endingEndpoint =
                   StaticEndpointBuilders.direct(
                       String.format(


### PR DESCRIPTION
# Description

If an integration scenario is used in a process orchestration but is not properly loaded as a spring component (@Disable used or autoloading not working) the error message is misleading. There is a typo in the error message format which needs to be fixed and full class name should be shown.

Fixes #1786

## Type of change

Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* SIP Framework version(s): 3.2.1-SNAPSHOT
* Other configuration:

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing (regression) unit tests pass locally with my changes
