### PR TITLE
SIP-1725|added swagger ui dependancy

### DIFF
--- a/changelogs/bugfix/missing_swagger_ui_dependancy_fix.json
+++ b/changelogs/bugfix/missing_swagger_ui_dependancy_fix.json
@@ -1,0 +1,5 @@
+{
+  "author": "LetoBukarica",
+  "pullrequestId": "243",
+  "message": "Added a Swagger UI dependency and test."
+}

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
         <camel.version>4.0.0</camel.version>
         <jackson-jsr310.version>2.12.7</jackson-jsr310.version>
         <springdoc-openapi.version>1.6.14</springdoc-openapi.version>
+        <springdoc-openapi-starter-webmvc-ui.version>2.3.0</springdoc-openapi-starter-webmvc-ui.version>
         <swagger-annotation.version>2.2.8</swagger-annotation.version>
         <lombok.version>1.18.24</lombok.version>
         <mapstruct.version>1.5.3.Final</mapstruct.version>
@@ -81,7 +82,7 @@
         <cxf.version>4.0.2</cxf.version>    <!-- keep in sync with camel-dependencies cxf-version property -->
         <snakeyaml.version>2.0</snakeyaml.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
-        <!-- maven dependancies -->
+        <!-- maven dependencies -->
         <maven-core.version>3.8.6</maven-core.version>
         <maven-project-dependecies.version>3.8.4</maven-project-dependecies.version>
         <maven-plugin-annotations.version>3.6.1</maven-plugin-annotations.version>
@@ -282,6 +283,11 @@
                 <groupId>org.springdoc</groupId>
                 <artifactId>springdoc-openapi-common</artifactId>
                 <version>${springdoc-openapi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springdoc</groupId>
+                <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                <version>${springdoc-openapi-starter-webmvc-ui.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -69,8 +69,8 @@
         <spring.boot.version>3.0.9</spring.boot.version>
         <camel.version>4.0.0</camel.version>
         <jackson-jsr310.version>2.12.7</jackson-jsr310.version>
-        <springdoc-openapi.version>1.6.14</springdoc-openapi.version>
-        <springdoc-openapi-starter-webmvc-ui.version>2.3.0</springdoc-openapi-starter-webmvc-ui.version>
+        <springdoc-openapi.version>1.7.0</springdoc-openapi.version>
+        <springdoc-openapi-starter-webmvc-ui.version>2.1.0</springdoc-openapi-starter-webmvc-ui.version>
         <swagger-annotation.version>2.2.8</swagger-annotation.version>
         <lombok.version>1.18.24</lombok.version>
         <mapstruct.version>1.5.3.Final</mapstruct.version>
@@ -288,6 +288,12 @@
                 <groupId>org.springdoc</groupId>
                 <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
                 <version>${springdoc-openapi-starter-webmvc-ui.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.swagger.core.v3</groupId>
+                        <artifactId>swagger-core-jakarta</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -69,8 +69,8 @@
         <spring.boot.version>3.0.9</spring.boot.version>
         <camel.version>4.0.0</camel.version>
         <jackson-jsr310.version>2.12.7</jackson-jsr310.version>
-        <springdoc-openapi.version>1.7.0</springdoc-openapi.version>
-        <springdoc-openapi-starter-webmvc-ui.version>2.1.0</springdoc-openapi-starter-webmvc-ui.version>
+        <springdoc-openapi.version>1.6.15</springdoc-openapi.version>
+        <springdoc-openapi-starter-webmvc-ui.version>2.0.3</springdoc-openapi-starter-webmvc-ui.version>
         <swagger-annotation.version>2.2.8</swagger-annotation.version>
         <lombok.version>1.18.24</lombok.version>
         <mapstruct.version>1.5.3.Final</mapstruct.version>

--- a/sip-core/pom.xml
+++ b/sip-core/pom.xml
@@ -122,6 +122,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <!-- Test dependencies-->

--- a/sip-core/pom.xml
+++ b/sip-core/pom.xml
@@ -119,6 +119,10 @@
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-jsonSchema</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+        </dependency>
 
         <!-- Test dependencies-->
         <dependency>

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/openapi/OpenApiTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/openapi/OpenApiTest.java
@@ -2,6 +2,10 @@ package de.ikor.sip.foundation.core.openapi;
 
 import static de.ikor.sip.foundation.core.CoreTestApplication.REST_ENDPOINT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import de.ikor.sip.foundation.core.CoreTestApplication;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -10,18 +14,22 @@ import org.apache.camel.Exchange;
 import org.apache.camel.ProducerTemplate;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest(
     classes = CoreTestApplication.class,
     properties = {"camel.servlet.mapping.context-path=/adapter/*"})
+@AutoConfigureMockMvc
 @DirtiesContext
-class OpenApiContextPathResolverTest {
+class OpenApiTest {
 
   @Autowired OpenAPI camelRestDSLOpenApi;
   @Autowired CamelContext camelContext;
   @Autowired ProducerTemplate producerTemplate;
+  @Autowired private MockMvc mvcBean;
 
   @Test
   void When_resolveCamelContextPathInOpenApi_Expect_ContextPathAdded() {
@@ -35,5 +43,14 @@ class OpenApiContextPathResolverTest {
     // assert
     assertThat(body).contains(REST_ENDPOINT).doesNotContain(contextPath + REST_ENDPOINT);
     assertThat(camelRestDSLOpenApi.getPaths()).containsKey(contextPath + REST_ENDPOINT);
+  }
+
+  @Test
+  void When_fetchingSwaggerUI_THEN_UI_is_shown() throws Exception {
+    // act & assert
+    mvcBean
+        .perform(get("/swagger-ui/index.html"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("<title>Swagger UI</title>")));
   }
 }


### PR DESCRIPTION
# Description

In the last version update of Spring we missed some libraries which were split. Consequence of that is that Swagger UI is not visible by default. I've added a library and an integration test to cover for those cases in the future.

Fixes # 1725

## Type of change

Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
- [X] TDD OpenApiTest

**Test Configuration**:
* SIP Framework version(s): 3.2.1-SNAPSHOT
* Other configuration:

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing (regression) unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
