### PR TITLE
SIP-1796|updated archetype to include full example and reordered para…

### DIFF
--- a/changelogs/documentation/archetype_docs_example.json
+++ b/changelogs/documentation/archetype_docs_example.json
@@ -1,0 +1,5 @@
+{
+  "author": "LetoBukarica",
+  "pullrequestId": "250",
+  "message": "Updated archetype documentation."
+}

--- a/docs-snapshot/archetype.md
+++ b/docs-snapshot/archetype.md
@@ -1,0 +1,86 @@
+# SIP Archetype
+
+[TOC]
+
+## Description
+
+This Maven Archetype creates a basic SIP Adapter project with a defined structure and necessary dependencies.
+
+## How to create a SIP Adapter using SIP Archetype
+
+In order to make setting up a new integration adapter project an easy task, we have created a dedicated SIP (Adapter) Maven archetype, that gives the ability to quickly bootstrap a new integration adapter, along with all needed Maven dependencies and goodies, as well as the recommended, preferred organization of the project.
+
+You can create a SIP Adapter by using the following Maven command:
+
+```shell
+  mvn archetype:generate -DarchetypeGroupId=de.ikor.sip.foundation -DarchetypeArtifactId=sip-archetype -DarchetypeVersion=<latest.sip-framework.version> -DgroupId=de.ikor.sip.adapter -DartifactId=demo -DprojectName=DemoAdapter -Dversion=1.0.0-SNAPSHOT
+```
+
+
+When executing the command, pay attention to use the latest archetype version for the `-DarchetypeVersion` parameter.
+Check available versions [here](https://search.maven.org/search?q=de.ikor.sip.foundation).
+
+**Overview of the command**
+```shell
+mvn archetype:generate
+-DarchetypeGroupId=de.ikor.sip.foundation
+-DarchetypeArtifactId=sip-archetype
+-DarchetypeVersion=<latest.sip-archetype.version>
+-DgroupId=de.ikor.sip.adapter
+-DartifactId=demo
+-DprojectName=DemoAdapter
+-Dversion=1.0.0-SNAPSHOT
+```
+
+The parameters `-DgroupId`, `-DartifactId`, `-DprojectName` and `-Dversion` should be adjusted to better match your project,
+as they set the properties for the adapter. It is recommended to follow the Maven naming convention since they are going to be presented in the _pom.xml_ file of the generated adapter.
+
+After executing given Maven command, you will be requested to insert additional parameters about project structure:
+
+- **connectorGroup1**/**connectorGroup2** are representing names of your connector group packages inside the project. It will also be reflected in the generated package structure (for example - all of the sources for connectorGroup1 will be in the _de.ikor.sip.adapter.sufix.connectorGroup1_ package)
+- **packageSuffix** is used to create project package name by concatenating its value to the **groupId**. There is a strict validation
+  for using only lower case letters and should be a single word. This will reflect the generated package structure for the generated project files. (for example - all of the sources will be in the _de.ikor.sip.adapter.sufix_ java package) 
+- **useLombok** is used for including or excluding Lombok dependency in adapter. Lombok is included by default. If you wish to exclude lombok you should set 
+  useLombok to anything other than 'y' or 'Y'.
+- **useSoap** is used for including or excluding _SIP SOAP Starter_ dependency in adapter. It is useful to include this starter if the adapter is planned to use SOAP since it has pre-built bootstrap elements included. It is false by default.
+- **package** (optional) is used to override previous package naming and provide full package name. This can be skipped by leaving value empty.
+  It is strongly recommended to follow package naming convention, otherwise your project will be created but it will have
+  package naming errors.
+
+
+_Note_: All the parameters can be provided via command line if needed:
+
+```shell
+mvn archetype:generate -DarchetypeGroupId=de.ikor.sip.foundation -DarchetypeArtifactId=sip-archetype -DarchetypeVersion=<latest.sip-framework.version> -DgroupId=de.ikor.sip.adapter -DartifactId=demo -DprojectName=DemoAdapter -Dversion=1.0.0-SNAPSHOT -DconnectorGroup1=group1 -DconnectorGroup2=group2 -DpackageSuffix=project -DuseLombok=y -DuseSoap=n -Dpackage=de.ikor.sip.adapter.demo.project
+```
+
+After a successful build, a project with the following structure will be created:
+
+- SIPApplication.java
+- common
+  - config
+  - util
+- connectorgroups
+  - {connectorGroup1}
+    - config
+    - models
+    - processors
+    - connectors
+    - transformers
+    - validators
+  - {connectorGroup2}
+    - config
+    - models
+    - processors
+    - connectors
+    - transformers
+    - validators
+- scenarios
+  - models
+  - definitions
+    
+
+More about packages and internal SIP structure can be found [here](./README.md).
+
+More information about Maven archetypes is available here:
+[Maven Archetype](https://maven.apache.org/guides/introduction/introduction-to-archetypes.html)

--- a/docs-snapshot/framework_version_upgrade.md
+++ b/docs-snapshot/framework_version_upgrade.md
@@ -2,9 +2,9 @@
 
 [TOC]
 
-## Upgrade from 3.2.0 to 3.2.1
+## Upgrade from 3.2.0 to 3.3.0
 
-This is a bugfix version, so it's shouldn't introduce any braking changes. 
+This is mostly a dependencies update and bugfix version, so it's shouldn't introduce any braking changes. 
 However, in the previous version, Integration Scenario model validation was triggered conditionally
 depending on the presence of Connector's response model (instead of Integration Scenario's).
 This has been changed, and the response transformation in the connector is now triggered unconditionally as well.


### PR DESCRIPTION
# Description

Update of the archetype docs to include an example with all the parameters are provided via command line. Also reordered the parameters to match prompts from archetype.

Fixes #238 

## Type of change

Please delete options that are not relevant.
- [X] This change requires a documentation update


**Test Configuration**:
* SIP Framework version(s) : 3.2.1-SNAPSHOT
* Other configuration:

# Checklist:
- [X] I have made corresponding changes to the documentation

