### PR TITLE
Support for dynamic endpoints

### DIFF
--- a/changelogs/feature/support-dynamic-endpoints.json
+++ b/changelogs/feature/support-dynamic-endpoints.json
@@ -1,0 +1,5 @@
+{
+  "author": "Nemikor",
+  "pullrequestId": "259",
+  "message": "Add support for dynamic endpoints in outbound connectors. The type of endpoint will be determined automatically based on presence of placeholders in uri."
+}

--- a/docs-snapshot/declarative.md
+++ b/docs-snapshot/declarative.md
@@ -251,10 +251,10 @@ This is illustrated in the example below.
       responseModel = OutboundConnectorResponse.class)
   public class DemoOutboundConnector extends GenericOutboundConnectorBase {
 
-    // external endpoint definition
+    // external endpoint definition with dynamic endpoint
     @Override
     protected EndpointProducerBuilder defineOutgoingEndpoint() {
-      return StaticEndpointBuilders.http("localhost:8080/update");
+      return StaticEndpointBuilders.http("localhost:8080/update/${header.id}");
     }
 
     @Override
@@ -265,7 +265,11 @@ This is illustrated in the example below.
     }
 
     protected void defineRequestRoute(final RouteDefinition definition) {
-        definition.process(exchange -> System.out.println("Processing and transformation before external system call"));
+        definition.process(exchange -> {
+            System.out.println("Processing and transformation before external system call");
+            // will be evaluated in endpoint uri to invoke http://localhost:8080/update/randomId
+            exchange.getMessage().setHeader("id", "randomId");
+        });
     }
 
     protected void defineResponseRoute(final RouteDefinition definition) {

--- a/docs-snapshot/declarative.md
+++ b/docs-snapshot/declarative.md
@@ -232,6 +232,8 @@ Same as inbound, the behaviour is defined through overridden method implementati
 *EndpointProducerBuilder defineOutgoingEndpoint()* is used to define the endpoint, 
 which executes the call to an external system.
 StaticEndpointBuilders can be used to provide the endpoint definition. **Apache Camel** is used in the Outbound endpoints as well.
+If the URI of the endpoint contains placeholder values in format of ${placeholder} or {{placeholder}}
+the endpoint will automatically be converted into a dynamic endpoint (toD).
 
 Defining processing and transformation is done in *Orchestrator<ConnectorOrchestrationInfo> defineTransformationOrchestrator()*.
 Here an Orchestrator needs to be returned, which is available from ConnectorOrchestrator

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/GenericOutboundConnectorBase.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/GenericOutboundConnectorBase.java
@@ -8,7 +8,6 @@ import de.ikor.sip.foundation.core.declarative.model.MarshallerDefinition;
 import de.ikor.sip.foundation.core.declarative.model.UnmarshallerDefinition;
 import de.ikor.sip.foundation.core.declarative.utils.DeclarativeReflectionUtils;
 import java.util.Optional;
-
 import org.apache.camel.builder.EndpointProducerBuilder;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.commons.lang3.StringUtils;

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/GenericOutboundConnectorBase.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/GenericOutboundConnectorBase.java
@@ -1,5 +1,6 @@
 package de.ikor.sip.foundation.core.declarative.connector;
 
+import static de.ikor.sip.foundation.core.declarative.utils.DeclarativeHelper.doesUriContainPlaceholders;
 import static de.ikor.sip.foundation.core.declarative.utils.DeclarativeHelper.formatConnectorId;
 
 import de.ikor.sip.foundation.core.declarative.annonation.OutboundConnector;
@@ -7,6 +8,7 @@ import de.ikor.sip.foundation.core.declarative.model.MarshallerDefinition;
 import de.ikor.sip.foundation.core.declarative.model.UnmarshallerDefinition;
 import de.ikor.sip.foundation.core.declarative.utils.DeclarativeReflectionUtils;
 import java.util.Optional;
+
 import org.apache.camel.builder.EndpointProducerBuilder;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.commons.lang3.StringUtils;
@@ -34,9 +36,14 @@ public abstract class GenericOutboundConnectorBase extends ConnectorBase
           formatConnectorId(getConnectorType(), getScenarioId(), getConnectorGroupId()));
 
   @Override
-  public final void defineOutboundEndpoints(final RouteDefinition routeDefinition) {
+  public void defineOutboundEndpoints(final RouteDefinition routeDefinition) {
     defineRequestMarshalling().ifPresent(marshaller -> marshaller.accept(routeDefinition));
-    routeDefinition.to(defineOutgoingEndpoint()).id(routeDefinition.getRouteId());
+    EndpointProducerBuilder endpoint = defineOutgoingEndpoint();
+    if (doesUriContainPlaceholders(endpoint.getUri())) {
+      routeDefinition.toD(endpoint).id(routeDefinition.getRouteId());
+    } else {
+      routeDefinition.to(endpoint).id(routeDefinition.getRouteId());
+    }
     defineResponseUnmarshalling().ifPresent(unmarshaller -> unmarshaller.accept(routeDefinition));
   }
 

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/GenericOutboundConnectorBase.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/GenericOutboundConnectorBase.java
@@ -35,7 +35,7 @@ public abstract class GenericOutboundConnectorBase extends ConnectorBase
           formatConnectorId(getConnectorType(), getScenarioId(), getConnectorGroupId()));
 
   @Override
-  public void defineOutboundEndpoints(final RouteDefinition routeDefinition) {
+  public final void defineOutboundEndpoints(final RouteDefinition routeDefinition) {
     defineRequestMarshalling().ifPresent(marshaller -> marshaller.accept(routeDefinition));
     EndpointProducerBuilder endpoint = defineOutgoingEndpoint();
     if (doesUriContainPlaceholders(endpoint.getUri())) {

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/utils/DeclarativeHelper.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/utils/DeclarativeHelper.java
@@ -125,14 +125,7 @@ public class DeclarativeHelper {
    */
   public static boolean doesUriContainPlaceholders(String uri) {
     Matcher dollarMatcher = DOLLAR_PLACEHOLDER_PATTERN.matcher(uri);
-    if (dollarMatcher.find()) {
-      return true;
-    }
     Matcher doubleCurlyMatcher = DOUBLE_CURLY_PLACEHOLDER_PATTERN.matcher(uri);
-    if (doubleCurlyMatcher.find()) {
-      return true;
-    }
-
-    return false;
+    return dollarMatcher.find() || doubleCurlyMatcher.find();
   }
 }

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/utils/DeclarativeHelper.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/utils/DeclarativeHelper.java
@@ -11,6 +11,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import lombok.experimental.UtilityClass;
 import org.apache.camel.Endpoint;
 import org.apache.camel.builder.EndpointConsumerBuilder;
@@ -26,6 +29,7 @@ import org.mapstruct.factory.Mappers;
 public class DeclarativeHelper {
 
   public static final String CONNECTOR_ID_FORMAT = "%s-%s-%s";
+  private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{([^}]+)}");
 
   public static String formatConnectorId(
       ConnectorType type, String scenarioID, String connectorGroupID) {
@@ -110,5 +114,15 @@ public class DeclarativeHelper {
   private static boolean isOutboundPrimaryEndpoint(ConnectorType type, String role) {
     return type.equals(ConnectorType.OUT)
         && (role.equals(RouteRole.EXTERNAL_ENDPOINT.getExternalName()));
+  }
+
+  /**
+   * Checks whether provided string URI contains any placeholders
+   * @param uri URI to be checked
+   * @return true if URI contains placeholders
+   */
+  public static boolean doesUriContainPlaceholders(String uri) {
+    Matcher matcher = PLACEHOLDER_PATTERN.matcher(uri);
+    return matcher.find();
   }
 }

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/utils/DeclarativeHelper.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/utils/DeclarativeHelper.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import lombok.experimental.UtilityClass;
 import org.apache.camel.Endpoint;
 import org.apache.camel.builder.EndpointConsumerBuilder;
@@ -29,7 +28,9 @@ import org.mapstruct.factory.Mappers;
 public class DeclarativeHelper {
 
   public static final String CONNECTOR_ID_FORMAT = "%s-%s-%s";
-  private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{([^}]+)}");
+  private static final Pattern DOLLAR_PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{[^}]+\\}");
+  private static final Pattern DOUBLE_CURLY_PLACEHOLDER_PATTERN =
+      Pattern.compile("\\{\\{[^}]+\\}\\}");
 
   public static String formatConnectorId(
       ConnectorType type, String scenarioID, String connectorGroupID) {
@@ -118,11 +119,20 @@ public class DeclarativeHelper {
 
   /**
    * Checks whether provided string URI contains any placeholders
+   *
    * @param uri URI to be checked
    * @return true if URI contains placeholders
    */
   public static boolean doesUriContainPlaceholders(String uri) {
-    Matcher matcher = PLACEHOLDER_PATTERN.matcher(uri);
-    return matcher.find();
+    Matcher dollarMatcher = DOLLAR_PLACEHOLDER_PATTERN.matcher(uri);
+    if (dollarMatcher.find()) {
+      return true;
+    }
+    Matcher doubleCurlyMatcher = DOUBLE_CURLY_PLACEHOLDER_PATTERN.matcher(uri);
+    if (doubleCurlyMatcher.find()) {
+      return true;
+    }
+
+    return false;
   }
 }

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/declarative/utils/DeclarativeHelperTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/declarative/utils/DeclarativeHelperTest.java
@@ -17,6 +17,8 @@ import java.util.Random;
 import org.apache.camel.builder.EndpointConsumerBuilder;
 import org.apache.camel.builder.endpoint.StaticEndpointBuilders;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class DeclarativeHelperTest {
 
@@ -147,5 +149,23 @@ class DeclarativeHelperTest {
                     DeclarativeHelper.isPrimaryEndpoint(
                         ConnectorType.OUT, RouteRole.EXTERNAL_SOAP_SERVICE_PROXY.getExternalName()))
                 .isFalse());
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "http:localhost/{{address}}",
+        "http:localhost/${address}",
+        "http:localhost/{{address}}/${path}",
+        "http:localhost/${path}/{{address}}"
+      })
+  void WHEN_CheckingURIWithPlaceholders_THEN_true(String uri) {
+    assertThat(DeclarativeHelper.doesUriContainPlaceholders(uri)).isTrue();
+  }
+
+  @Test
+  void WHEN_CheckingURI_WITH_NoPlaceholder_THEN_EvaluateAsFalse() {
+    String uri = "http:localhost";
+    assertThat(DeclarativeHelper.doesUriContainPlaceholders(uri)).isFalse();
   }
 }


### PR DESCRIPTION
# Description

Automatically determine whether to use to(..) or toD(..) based on placeholders in endpoint uri of outbound connectors

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Created a new adapter with an outbound connector whose endpoint contains placeholders which use values from headers.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing (regression) unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
