### PR TITLE
Fix missing headers and path resolving in Test Kit

### DIFF
--- a/changelogs/bugfix/fix-rest-headers-test-kit.json
+++ b/changelogs/bugfix/fix-rest-headers-test-kit.json
@@ -1,0 +1,5 @@
+{
+  "author": "Nemikor",
+  "pullrequestId": "264",
+  "message": "Fix an issue where REST headers were not taken from test case definition. Enable resolving path parameters of rest endpoints using headers."
+}

--- a/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/util/HttpInvokerHelper.java
+++ b/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/util/HttpInvokerHelper.java
@@ -2,6 +2,8 @@ package de.ikor.sip.foundation.testkit.util;
 
 import de.ikor.sip.foundation.core.proxies.ProcessorProxy;
 import de.ikor.sip.foundation.testkit.workflow.whenphase.routeinvoker.RouteInvoker;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
@@ -23,13 +25,32 @@ public class HttpInvokerHelper {
    */
   public static MultiValueMap<String, String> prepareHeaders(Exchange exchange) {
     MultiValueMap<String, String> headers = new HttpHeaders();
-    headers.add(
+    Map<String, Object> existingHeaders = exchange.getMessage().getHeaders();
+
+    existingHeaders.forEach(
+        (key, value) -> {
+          if (value instanceof List) {
+            ((List<?>) value).forEach(val -> headers.add(key, val.toString()));
+          } else {
+            headers.add(key, value.toString());
+          }
+        });
+    addHeaderIfAbsent(
+        headers,
         RouteInvoker.TEST_NAME_HEADER,
         exchange.getMessage().getHeader(RouteInvoker.TEST_NAME_HEADER, String.class));
-    headers.add(
+    addHeaderIfAbsent(
+        headers,
         ProcessorProxy.TEST_MODE_HEADER,
         exchange.getMessage().getHeader(ProcessorProxy.TEST_MODE_HEADER, String.class));
     return headers;
+  }
+
+  private static void addHeaderIfAbsent(
+      MultiValueMap<String, String> headers, String headerName, String headerValue) {
+    if (!headers.containsKey(headerName) && headerValue != null) {
+      headers.add(headerName, headerValue);
+    }
   }
 
   /**

--- a/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/workflow/whenphase/routeinvoker/impl/RestRouteInvoker.java
+++ b/sip-test-kit/src/main/java/de/ikor/sip/foundation/testkit/workflow/whenphase/routeinvoker/impl/RestRouteInvoker.java
@@ -21,6 +21,8 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /** Invoker class for triggering Camel REST route */
 @Slf4j
@@ -38,16 +40,16 @@ public class RestRouteInvoker implements RouteInvoker {
   @Override
   public Optional<Exchange> invoke(Exchange inputExchange) {
     Endpoint endpoint = TestKitHelper.resolveEndpoint(inputExchange, camelContext);
+    MultiValueMap<String, String> headers = prepareHeaders(inputExchange);
     HttpEntity<String> testRequest =
-        new HttpEntity<>(
-            inputExchange.getMessage().getBody(String.class), prepareHeaders(inputExchange));
+        new HttpEntity<>(inputExchange.getMessage().getBody(String.class), headers);
     log.trace("sip.testkit.workflow.whenphase.routeinvoker.rest.request_{}", testRequest);
 
     ResponseEntity<String> response =
         restTemplateBuilder
             .build()
             .exchange(
-                createUri(endpoint),
+                createUri(endpoint, headers),
                 resolveHttpMethod(endpoint),
                 testRequest,
                 new ParameterizedTypeReference<>() {});
@@ -61,12 +63,14 @@ public class RestRouteInvoker implements RouteInvoker {
     return endpoint instanceof RestEndpoint;
   }
 
-  private String createUri(Endpoint endpoint) {
+  private String createUri(Endpoint endpoint, MultiValueMap<String, String> headers) {
+    String resolvedUrl =
+        UriComponentsBuilder.fromUriString(((RestEndpoint) endpoint).getPath())
+            .buildAndExpand(headers.toSingleValueMap())
+            .toUriString();
     return String.format(
         "http://localhost:%s%s/%s",
-        environment.getProperty("local.server.port"),
-        resolveContextPath(),
-        ((RestEndpoint) endpoint).getPath());
+        environment.getProperty("local.server.port"), resolveContextPath(), resolvedUrl);
   }
 
   private String resolveContextPath() {

--- a/sip-test-kit/src/test/java/de/ikor/sip/foundation/testkit/workflow/whenphase/routeinvoker/impl/RestRouteInvokerTest.java
+++ b/sip-test-kit/src/test/java/de/ikor/sip/foundation/testkit/workflow/whenphase/routeinvoker/impl/RestRouteInvokerTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.*;
 import de.ikor.sip.foundation.core.proxies.ProcessorProxy;
 import de.ikor.sip.foundation.testkit.workflow.givenphase.Mock;
 import de.ikor.sip.foundation.testkit.workflow.whenphase.routeinvoker.RouteInvoker;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
@@ -124,6 +126,29 @@ class RestRouteInvokerTest {
         .exchange(
             anyString(),
             eq(HttpMethod.POST),
+            any(),
+            ArgumentMatchers.<ParameterizedTypeReference<String>>any());
+  }
+
+  @Test
+  void GIVEN_EndpointWithPathParams_WHEN_executeTask_THEN_ParamsResolved() {
+    // arrange
+    when(restEndpoint.getMethod()).thenReturn("get");
+    when(restEndpoint.getPath()).thenReturn("test/{headerKey}");
+    Map<String, Object> headers = new HashMap<>();
+    headers.put(RouteInvoker.TEST_NAME_HEADER, "test");
+    headers.put(ProcessorProxy.TEST_MODE_HEADER, "true");
+    headers.put("headerKey", "headerValue");
+    when(exchange.getMessage().getHeaders()).thenReturn(headers);
+    // act
+    Optional<Exchange> target = restRouteInvoker.invoke(exchange);
+
+    // assert
+    assertThat(target).isPresent();
+    verify(restTemplate)
+        .exchange(
+            contains("headerValue"),
+            eq(HttpMethod.GET),
             any(),
             ArgumentMatchers.<ParameterizedTypeReference<String>>any());
   }


### PR DESCRIPTION
# Description

Fix an issue where headers from test case definition were not added to request when the test was using REST invoker.
Also added path resolver which will use headers to add path params to uri.


## Type of change

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing (regression) unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
