### PR TITLE
Improved error message for wrapped connector processor methods

### DIFF
--- a/changelogs/bugfix/fix-bad-error-message-for-connector-processor-methods.json
+++ b/changelogs/bugfix/fix-bad-error-message-for-connector-processor-methods.json
@@ -1,0 +1,5 @@
+{
+  "author": "MartinBuchheim",
+  "pullrequestId": "268",
+  "message": "Improved error message when an exception is triggered from a method-based connector processor"
+}

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/MethodBasedConnectorProcessor.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/MethodBasedConnectorProcessor.java
@@ -83,9 +83,10 @@ public class MethodBasedConnectorProcessor implements ConnectorProcessor {
     } catch (InvocationTargetException e) {
       throw SIPFrameworkException.init(
           e.getCause(),
-          "Connector processor failed for method %s in connector-class %s",
+          "An error occurred while running connector processor method %s in connector-class %s: %s",
           processorMethod.getName(),
-          connector.getClass().getName());
+          connector.getClass().getName(),
+          e.getCause().getMessage());
     } catch (IllegalAccessException e) {
       throw SIPFrameworkException.init(
           e,

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/MethodBasedConnectorProcessor.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/MethodBasedConnectorProcessor.java
@@ -8,11 +8,7 @@ import jakarta.annotation.Nullable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 import lombok.Getter;
 import lombok.ToString;
@@ -28,14 +24,17 @@ public class MethodBasedConnectorProcessor implements ConnectorProcessor {
   @Getter @ToString.Include protected final ConnectorDefinition connector;
   @Getter @ToString.Include protected final Method processorMethod;
   @Getter protected final Set<Class<?>> requestedBodyTypes;
-  @Getter protected final Class<?> returnType;
+  @Getter protected final Optional<Class<?>> returnType;
   protected final List<Function<Exchange, Object>> parameterFetchers;
 
   public MethodBasedConnectorProcessor(
       final ConnectorDefinition connector, final Method processorMethod) {
     this.connector = connector;
     this.processorMethod = processorMethod;
-    this.returnType = processorMethod.getReturnType();
+    this.returnType =
+        !Void.TYPE.equals(processorMethod.getReturnType())
+            ? Optional.of(processorMethod.getReturnType())
+            : Optional.empty();
     Set<Class<?>> bodyTypes = new HashSet<>();
     parameterFetchers =
         Arrays.stream(processorMethod.getParameters())
@@ -80,13 +79,17 @@ public class MethodBasedConnectorProcessor implements ConnectorProcessor {
     try {
       final var args = parameterFetchers.stream().map(fetcher -> fetcher.apply(exchange)).toArray();
       final var result = processorMethod.invoke(connector, args);
-      if (!Void.TYPE.equals(getReturnType())) {
-        exchange.getMessage().setBody(result, getReturnType());
-      }
-    } catch (InvocationTargetException | IllegalAccessException e) {
+      getReturnType().ifPresent(type -> exchange.getMessage().setBody(result, type));
+    } catch (InvocationTargetException e) {
+      throw SIPFrameworkException.init(
+          e.getCause(),
+          "Connector processor failed for method %s in connector-class %s",
+          processorMethod.getName(),
+          connector.getClass().getName());
+    } catch (IllegalAccessException e) {
       throw SIPFrameworkException.init(
           e,
-          "Parameter-binding failed for method %s in connector-class %s",
+          "Failed to run connector processor method %s in connector-class %s",
           processorMethod.getName(),
           connector.getClass().getName());
     }

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/MethodBasedConnectorProcessor.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/MethodBasedConnectorProcessor.java
@@ -83,14 +83,14 @@ public class MethodBasedConnectorProcessor implements ConnectorProcessor {
     } catch (InvocationTargetException e) {
       throw SIPFrameworkException.init(
           e.getCause(),
-          "An error occurred while running connector processor method %s in connector-class %s: %s",
+          "An error occurred while running connector processor method '%s' in connector-class %s: %s",
           processorMethod.getName(),
           connector.getClass().getName(),
           e.getCause().getMessage());
     } catch (IllegalAccessException e) {
       throw SIPFrameworkException.init(
           e,
-          "Failed to run connector processor method %s in connector-class %s",
+          "Failed to run connector processor method '%s' in connector-class %s",
           processorMethod.getName(),
           connector.getClass().getName());
     }


### PR DESCRIPTION
# Description

When an exception occured in a method-based connector processor, the previous error always stated a problem with the parameter type conversion, even if any different exception was thrown from the adapters method body

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing (regression) unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
