### PR TITLE
Extract mapper beans from context

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -98,7 +98,7 @@ jobs:
       run: mvn ${MAVEN_ARGS} javadoc:aggregate -Pjavadoc-lint-html
     - name: 'Upload Javadoc Artifact'
       if: ${{ github.ref == 'refs/heads/develop' }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: javadoc
         path: target/site/apidocs/*
@@ -122,7 +122,7 @@ jobs:
         git rm -r javadoc/latest || true
         mkdir -p javadoc/latest
     - name: Download newer javadoc
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: javadoc
         path: javadoc/latest

--- a/changelogs/bugfix/spring_mapper_in_connectors.json
+++ b/changelogs/bugfix/spring_mapper_in_connectors.json
@@ -1,0 +1,5 @@
+{
+  "author": "Nemikor",
+  "pullrequestId": "271",
+  "message": "Add support for using mapstruct mappers created with spring framework in connectors."
+}

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/ConnectorBase.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/ConnectorBase.java
@@ -57,42 +57,6 @@ public abstract non-sealed class ConnectorBase
   @Getter(AccessLevel.PROTECTED)
   private ApplicationContext applicationContext;
 
-  @SuppressWarnings({"unchecked", "OptionalUsedAsFieldOrParameterType"})
-  private Optional<RequestMappingRouteTransformer<?, ?>> requestMappingRouteTransformer;
-
-  private Optional<RequestMappingRouteTransformer<?, ?>> getRequestMappingRouteTransformer() {
-    if (requestMappingRouteTransformer == null)
-      requestMappingRouteTransformer =
-          DeclarativeReflectionUtils.getAnnotationIfPresent(UseRequestModelMapper.class, this)
-              .map(
-                  annotation ->
-                      DeclarativeHelper.createMapperInstance(
-                          applicationContext, annotation.value()))
-              .map(
-                  mapper ->
-                      RequestMappingRouteTransformer.forConnectorWithScenario(
-                          this, getScenario(), mapper));
-    return requestMappingRouteTransformer;
-  }
-
-  @SuppressWarnings({"unchecked", "OptionalUsedAsFieldOrParameterType"})
-  private Optional<ResponseMappingRouteTransformer<?, ?>> responseMappingRouteTransformer;
-
-  private Optional<ResponseMappingRouteTransformer<?, ?>> getResponseMappingRouteTransformer() {
-    if (responseMappingRouteTransformer == null)
-      responseMappingRouteTransformer =
-          DeclarativeReflectionUtils.getAnnotationIfPresent(UseResponseModelMapper.class, this)
-              .map(
-                  annotation ->
-                      DeclarativeHelper.createMapperInstance(
-                          applicationContext, annotation.value()))
-              .map(
-                  mapper ->
-                      ResponseMappingRouteTransformer.forConnectorWithScenario(
-                          this, getScenario(), mapper));
-    return responseMappingRouteTransformer;
-  }
-
   @Delegate private Orchestrator<ConnectorOrchestrationInfo> modelTransformationOrchestrator;
 
   @Override
@@ -211,5 +175,27 @@ public abstract non-sealed class ConnectorBase
   @Override
   public final List<Method> getOnExceptionHandler() {
     return onExceptionHandlers;
+  }
+
+  private Optional<RequestMappingRouteTransformer<?, ?>> getRequestMappingRouteTransformer() {
+    return DeclarativeReflectionUtils.getAnnotationIfPresent(UseRequestModelMapper.class, this)
+        .map(
+            annotation ->
+                DeclarativeHelper.createMapperInstance(applicationContext, annotation.value()))
+        .map(
+            mapper ->
+                RequestMappingRouteTransformer.forConnectorWithScenario(
+                    this, getScenario(), mapper));
+  }
+
+  private Optional<ResponseMappingRouteTransformer<?, ?>> getResponseMappingRouteTransformer() {
+    return DeclarativeReflectionUtils.getAnnotationIfPresent(UseResponseModelMapper.class, this)
+        .map(
+            annotation ->
+                DeclarativeHelper.createMapperInstance(applicationContext, annotation.value()))
+        .map(
+            mapper ->
+                ResponseMappingRouteTransformer.forConnectorWithScenario(
+                    this, getScenario(), mapper));
   }
 }

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/ConnectorBase.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/ConnectorBase.java
@@ -97,8 +97,7 @@ public abstract non-sealed class ConnectorBase
    */
   @Deprecated(since = "3.4.0")
   protected Orchestrator<ConnectorOrchestrationInfo> defineTransformationOrchestrator() {
-    final var orchestrator = ConnectorOrchestrator.forConnector(this);
-    return orchestrator;
+    return ConnectorOrchestrator.forConnector(this);
   }
 
   private boolean isDeprecatedTransformationOrchestrationOverloaded() {
@@ -124,24 +123,21 @@ public abstract non-sealed class ConnectorBase
             getClass().getName());
     @Deprecated final var transformationOrchestrator = defineTransformationOrchestrator();
 
-    if (transformationOrchestrator
-        instanceof @SuppressWarnings("deprecation") ConnectorOrchestrator connectorOrchestrator) {
+    if (transformationOrchestrator instanceof ConnectorOrchestrator) {
       DeclarativeReflectionUtils.getAnnotationIfPresent(UseRequestModelMapper.class, this)
           .ifPresent(
-              transformer ->
-                  SIPFrameworkInitializationException.throwIf(
-                      !transformer.equals(connectorOrchestrator.getRequestRouteTransformer()),
-                      "Connector %s specifies custom request-transformation in it's orchestrator, and at the same time has annotation @%s present, which is not allowed.",
-                      getClass().getName(),
-                      UseRequestModelMapper.class.getSimpleName()));
+              transformer -> {
+                throw SIPFrameworkInitializationException.init(
+                    "Connector %s specifies custom request-transformation in it's orchestrator, and at the same time has annotation @%s present, which is not allowed.",
+                    getClass().getName(), UseRequestModelMapper.class.getSimpleName());
+              });
       DeclarativeReflectionUtils.getAnnotationIfPresent(UseResponseModelMapper.class, this)
           .ifPresent(
-              transformer ->
-                  SIPFrameworkInitializationException.throwIf(
-                      !transformer.equals(connectorOrchestrator.getResponseRouteTransformer()),
-                      "Connector %s specifies custom response-transformation in it's orchestrator, and at the same time has annotation @%s present, which is not allowed.",
-                      getClass().getName(),
-                      UseResponseModelMapper.class.getSimpleName()));
+              transformer -> {
+                throw SIPFrameworkInitializationException.init(
+                    "Connector %s specifies custom response-transformation in it's orchestrator, and at the same time has annotation @%s present, which is not allowed.",
+                    getClass().getName(), UseResponseModelMapper.class.getSimpleName());
+              });
     } else {
       TRANSFORM_OVERLOAD_PROHIBITED_ANNOTATIONS.stream()
           .filter(annotation -> getClass().isAnnotationPresent(annotation))

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/ConnectorBase.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/ConnectorBase.java
@@ -123,7 +123,8 @@ public abstract non-sealed class ConnectorBase
             getClass().getName());
     @Deprecated final var transformationOrchestrator = defineTransformationOrchestrator();
 
-    if (transformationOrchestrator instanceof ConnectorOrchestrator) {
+    if (transformationOrchestrator
+        instanceof @SuppressWarnings("deprecation") ConnectorOrchestrator connectorOrchestrator) {
       DeclarativeReflectionUtils.getAnnotationIfPresent(UseRequestModelMapper.class, this)
           .ifPresent(
               transformer -> {

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/ConnectorBase.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/ConnectorBase.java
@@ -6,14 +6,11 @@ import de.ikor.sip.foundation.core.declarative.annonation.UseRequestModelMapper;
 import de.ikor.sip.foundation.core.declarative.annonation.UseResponseModelMapper;
 import de.ikor.sip.foundation.core.declarative.annotation.connector.processor.RequestProcessor;
 import de.ikor.sip.foundation.core.declarative.annotation.connector.processor.ResponseProcessor;
-import de.ikor.sip.foundation.core.declarative.model.RequestMappingRouteTransformer;
-import de.ikor.sip.foundation.core.declarative.model.ResponseMappingRouteTransformer;
 import de.ikor.sip.foundation.core.declarative.orchestration.Orchestrator;
 import de.ikor.sip.foundation.core.declarative.orchestration.connector.ConnectorOrchestrationInfo;
 import de.ikor.sip.foundation.core.declarative.orchestration.connector.ConnectorOrchestrator;
 import de.ikor.sip.foundation.core.declarative.orchestration.connector.ConnectorProcessorChainOrchestrator;
 import de.ikor.sip.foundation.core.declarative.scenario.IntegrationScenarioDefinition;
-import de.ikor.sip.foundation.core.declarative.utils.DeclarativeHelper;
 import de.ikor.sip.foundation.core.declarative.utils.DeclarativeReflectionUtils;
 import de.ikor.sip.foundation.core.util.exception.SIPFrameworkInitializationException;
 import java.lang.annotation.Annotation;
@@ -101,8 +98,6 @@ public abstract non-sealed class ConnectorBase
   @Deprecated(since = "3.4.0")
   protected Orchestrator<ConnectorOrchestrationInfo> defineTransformationOrchestrator() {
     final var orchestrator = ConnectorOrchestrator.forConnector(this);
-    getRequestMappingRouteTransformer().ifPresent(orchestrator::setRequestRouteTransformer);
-    getResponseMappingRouteTransformer().ifPresent(orchestrator::setResponseRouteTransformer);
     return orchestrator;
   }
 
@@ -131,7 +126,7 @@ public abstract non-sealed class ConnectorBase
 
     if (transformationOrchestrator
         instanceof @SuppressWarnings("deprecation") ConnectorOrchestrator connectorOrchestrator) {
-      getRequestMappingRouteTransformer()
+      DeclarativeReflectionUtils.getAnnotationIfPresent(UseRequestModelMapper.class, this)
           .ifPresent(
               transformer ->
                   SIPFrameworkInitializationException.throwIf(
@@ -139,7 +134,7 @@ public abstract non-sealed class ConnectorBase
                       "Connector %s specifies custom request-transformation in it's orchestrator, and at the same time has annotation @%s present, which is not allowed.",
                       getClass().getName(),
                       UseRequestModelMapper.class.getSimpleName()));
-      getResponseMappingRouteTransformer()
+      DeclarativeReflectionUtils.getAnnotationIfPresent(UseResponseModelMapper.class, this)
           .ifPresent(
               transformer ->
                   SIPFrameworkInitializationException.throwIf(
@@ -175,27 +170,5 @@ public abstract non-sealed class ConnectorBase
   @Override
   public final List<Method> getOnExceptionHandler() {
     return onExceptionHandlers;
-  }
-
-  private Optional<RequestMappingRouteTransformer<?, ?>> getRequestMappingRouteTransformer() {
-    return DeclarativeReflectionUtils.getAnnotationIfPresent(UseRequestModelMapper.class, this)
-        .map(
-            annotation ->
-                DeclarativeHelper.createMapperInstance(applicationContext, annotation.value()))
-        .map(
-            mapper ->
-                RequestMappingRouteTransformer.forConnectorWithScenario(
-                    this, getScenario(), mapper));
-  }
-
-  private Optional<ResponseMappingRouteTransformer<?, ?>> getResponseMappingRouteTransformer() {
-    return DeclarativeReflectionUtils.getAnnotationIfPresent(UseResponseModelMapper.class, this)
-        .map(
-            annotation ->
-                DeclarativeHelper.createMapperInstance(applicationContext, annotation.value()))
-        .map(
-            mapper ->
-                ResponseMappingRouteTransformer.forConnectorWithScenario(
-                    this, getScenario(), mapper));
   }
 }

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/ConnectorBase.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/ConnectorBase.java
@@ -58,29 +58,48 @@ public abstract non-sealed class ConnectorBase
   private ApplicationContext applicationContext;
 
   @SuppressWarnings({"unchecked", "OptionalUsedAsFieldOrParameterType"})
-  private final Optional<RequestMappingRouteTransformer<?, ?>> requestMappingRouteTransformer =
-      DeclarativeReflectionUtils.getAnnotationIfPresent(UseRequestModelMapper.class, this)
-          .map(annotation -> DeclarativeHelper.createMapperInstance(annotation.value()))
-          .map(
-              mapper ->
-                  RequestMappingRouteTransformer.forConnectorWithScenario(
-                      this, getScenario(), mapper));
+  private Optional<RequestMappingRouteTransformer<?, ?>> requestMappingRouteTransformer;
+
+  private Optional<RequestMappingRouteTransformer<?, ?>> getRequestMappingRouteTransformer() {
+    if (requestMappingRouteTransformer == null)
+      requestMappingRouteTransformer =
+          DeclarativeReflectionUtils.getAnnotationIfPresent(UseRequestModelMapper.class, this)
+              .map(
+                  annotation ->
+                      DeclarativeHelper.createMapperInstance(
+                          applicationContext, annotation.value()))
+              .map(
+                  mapper ->
+                      RequestMappingRouteTransformer.forConnectorWithScenario(
+                          this, getScenario(), mapper));
+    return requestMappingRouteTransformer;
+  }
 
   @SuppressWarnings({"unchecked", "OptionalUsedAsFieldOrParameterType"})
-  private final Optional<ResponseMappingRouteTransformer<?, ?>> responseMappingRouteTransformer =
-      DeclarativeReflectionUtils.getAnnotationIfPresent(UseResponseModelMapper.class, this)
-          .map(annotation -> DeclarativeHelper.createMapperInstance(annotation.value()))
-          .map(
-              mapper ->
-                  ResponseMappingRouteTransformer.forConnectorWithScenario(
-                      this, getScenario(), mapper));
+  private Optional<ResponseMappingRouteTransformer<?, ?>> responseMappingRouteTransformer;
 
-  @Delegate
-  private final Orchestrator<ConnectorOrchestrationInfo> modelTransformationOrchestrator =
-      initConnectorOrchestrator();
+  private Optional<ResponseMappingRouteTransformer<?, ?>> getResponseMappingRouteTransformer() {
+    if (responseMappingRouteTransformer == null)
+      responseMappingRouteTransformer =
+          DeclarativeReflectionUtils.getAnnotationIfPresent(UseResponseModelMapper.class, this)
+              .map(
+                  annotation ->
+                      DeclarativeHelper.createMapperInstance(
+                          applicationContext, annotation.value()))
+              .map(
+                  mapper ->
+                      ResponseMappingRouteTransformer.forConnectorWithScenario(
+                          this, getScenario(), mapper));
+    return responseMappingRouteTransformer;
+  }
+
+  @Delegate private Orchestrator<ConnectorOrchestrationInfo> modelTransformationOrchestrator;
 
   @Override
   public Orchestrator<ConnectorOrchestrationInfo> getOrchestrator() {
+    if (modelTransformationOrchestrator == null) {
+      modelTransformationOrchestrator = initConnectorOrchestrator();
+    }
     return modelTransformationOrchestrator;
   }
 
@@ -118,8 +137,8 @@ public abstract non-sealed class ConnectorBase
   @Deprecated(since = "3.4.0")
   protected Orchestrator<ConnectorOrchestrationInfo> defineTransformationOrchestrator() {
     final var orchestrator = ConnectorOrchestrator.forConnector(this);
-    requestMappingRouteTransformer.ifPresent(orchestrator::setRequestRouteTransformer);
-    responseMappingRouteTransformer.ifPresent(orchestrator::setResponseRouteTransformer);
+    getRequestMappingRouteTransformer().ifPresent(orchestrator::setRequestRouteTransformer);
+    getResponseMappingRouteTransformer().ifPresent(orchestrator::setResponseRouteTransformer);
     return orchestrator;
   }
 
@@ -148,20 +167,22 @@ public abstract non-sealed class ConnectorBase
 
     if (transformationOrchestrator
         instanceof @SuppressWarnings("deprecation") ConnectorOrchestrator connectorOrchestrator) {
-      requestMappingRouteTransformer.ifPresent(
-          transformer ->
-              SIPFrameworkInitializationException.throwIf(
-                  !transformer.equals(connectorOrchestrator.getRequestRouteTransformer()),
-                  "Connector %s specifies custom request-transformation in it's orchestrator, and at the same time has annotation @%s present, which is not allowed.",
-                  getClass().getName(),
-                  UseRequestModelMapper.class.getSimpleName()));
-      responseMappingRouteTransformer.ifPresent(
-          transformer ->
-              SIPFrameworkInitializationException.throwIf(
-                  !transformer.equals(connectorOrchestrator.getResponseRouteTransformer()),
-                  "Connector %s specifies custom response-transformation in it's orchestrator, and at the same time has annotation @%s present, which is not allowed.",
-                  getClass().getName(),
-                  UseResponseModelMapper.class.getSimpleName()));
+      getRequestMappingRouteTransformer()
+          .ifPresent(
+              transformer ->
+                  SIPFrameworkInitializationException.throwIf(
+                      !transformer.equals(connectorOrchestrator.getRequestRouteTransformer()),
+                      "Connector %s specifies custom request-transformation in it's orchestrator, and at the same time has annotation @%s present, which is not allowed.",
+                      getClass().getName(),
+                      UseRequestModelMapper.class.getSimpleName()));
+      getResponseMappingRouteTransformer()
+          .ifPresent(
+              transformer ->
+                  SIPFrameworkInitializationException.throwIf(
+                      !transformer.equals(connectorOrchestrator.getResponseRouteTransformer()),
+                      "Connector %s specifies custom response-transformation in it's orchestrator, and at the same time has annotation @%s present, which is not allowed.",
+                      getClass().getName(),
+                      UseResponseModelMapper.class.getSimpleName()));
     } else {
       TRANSFORM_OVERLOAD_PROHIBITED_ANNOTATIONS.stream()
           .filter(annotation -> getClass().isAnnotationPresent(annotation))

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/orchestration/connector/ConnectorProcessorChainOrchestrator.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/orchestration/connector/ConnectorProcessorChainOrchestrator.java
@@ -276,11 +276,13 @@ public final class ConnectorProcessorChainOrchestrator
 
     // Register attached mappers
     registerMapperProcessor(
+        context,
         connector,
         requestExtensionsRegistry,
         UseRequestModelMapper.class,
         UseRequestModelMapper::value);
     registerMapperProcessor(
+        context,
         connector,
         responseExtensionsRegistry,
         UseResponseModelMapper.class,
@@ -288,13 +290,15 @@ public final class ConnectorProcessorChainOrchestrator
   }
 
   private <T extends Annotation> void registerMapperProcessor(
+      ApplicationContext context,
       final ConnectorDefinition connector,
       final Map<String, ConnectorProcessorRegistryEntry> registry,
       final Class<T> annotationClass,
       final Function<T, Class<? extends ModelMapper>> mapperFetcher) {
     if (connector.getClass().isAnnotationPresent(annotationClass)) {
       final var annotation = connector.getClass().getAnnotation(annotationClass);
-      final var mapper = DeclarativeHelper.createMapperInstance(mapperFetcher.apply(annotation));
+      final var mapper =
+          DeclarativeHelper.createMapperInstance(context, mapperFetcher.apply(annotation));
       final var entry =
           new ConnectorProcessorRegistryEntry(
               mapper, connector.getClass(), requestExtensionsRegistry);

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/utils/DeclarativeHelper.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/utils/DeclarativeHelper.java
@@ -75,6 +75,7 @@ public class DeclarativeHelper {
    */
   public static <T extends ModelMapper<?, ?>> T createMapperInstance(
       ApplicationContext context, Class<T> clazz) {
+    if (context == null) return createMapperInstance(clazz);
     try {
       return context.getBean(clazz);
     } catch (BeansException beansException) {

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/utils/DeclarativeHelper.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/utils/DeclarativeHelper.java
@@ -25,6 +25,8 @@ import org.apache.camel.builder.endpoint.dsl.JmsEndpointBuilderFactory;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.commons.lang3.StringUtils;
 import org.mapstruct.factory.Mappers;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
 
 /**
  * Helper methods for the declarative structure adapter building.
@@ -44,7 +46,7 @@ public class DeclarativeHelper {
     return String.format(CONNECTOR_ID_FORMAT, type.getValue(), scenarioID, connectorGroupID);
   }
 
-  public static <T extends ModelMapper> T createMapperInstance(Class<T> clazz) {
+  public static <T extends ModelMapper<?, ?>> T createMapperInstance(Class<T> clazz) {
     try {
       return Mappers.getMapper(clazz);
     } catch (RuntimeException e) {
@@ -60,6 +62,23 @@ public class DeclarativeHelper {
         throw SIPFrameworkInitializationException.init(
             exception, "SIP couldn't create a Mapper %s.", clazz.getName());
       }
+    }
+  }
+
+  /**
+   * Attempt to get mapper bean from context, otherwise create new mapper instance
+   *
+   * @param context {@link ApplicationContext}
+   * @param clazz mapper class
+   * @return instance of {@link ModelMapper}
+   * @param <T> mapper type
+   */
+  public static <T extends ModelMapper<?, ?>> T createMapperInstance(
+      ApplicationContext context, Class<T> clazz) {
+    try {
+      return context.getBean(clazz);
+    } catch (BeansException beansException) {
+      return createMapperInstance(clazz);
     }
   }
 

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/apps/declarative/MappingAdapter.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/apps/declarative/MappingAdapter.java
@@ -29,6 +29,7 @@ import org.apache.camel.builder.endpoint.StaticEndpointBuilders;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.camel.model.rest.RestBindingMode;
 import org.apache.camel.model.rest.RestDefinition;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.ComponentScan.Filter;
 
@@ -108,5 +109,10 @@ public class MappingAdapter {
     protected EndpointProducerBuilder defineOutgoingEndpoint() {
       return StaticEndpointBuilders.log("message");
     }
+  }
+
+  @Bean
+  public FrontEndSystemRequestMapper frontEndSystemRequestMapperBean() {
+    return new FrontEndSystemRequestMapper();
   }
 }

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/apps/declarative/MappingAdapter.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/apps/declarative/MappingAdapter.java
@@ -14,19 +14,17 @@ import de.ikor.sip.foundation.core.declarative.annonation.IntegrationScenario;
 import de.ikor.sip.foundation.core.declarative.annonation.OutboundConnector;
 import de.ikor.sip.foundation.core.declarative.annonation.UseRequestModelMapper;
 import de.ikor.sip.foundation.core.declarative.annonation.UseResponseModelMapper;
+import de.ikor.sip.foundation.core.declarative.annotation.connector.processor.ResponseProcessor;
 import de.ikor.sip.foundation.core.declarative.connector.GenericOutboundConnectorBase;
 import de.ikor.sip.foundation.core.declarative.connector.RestInboundConnectorBase;
 import de.ikor.sip.foundation.core.declarative.model.MarshallerDefinition;
 import de.ikor.sip.foundation.core.declarative.model.UnmarshallerDefinition;
-import de.ikor.sip.foundation.core.declarative.orchestration.Orchestrator;
-import de.ikor.sip.foundation.core.declarative.orchestration.connector.ConnectorOrchestrationInfo;
-import de.ikor.sip.foundation.core.declarative.orchestration.connector.ConnectorOrchestrator;
 import de.ikor.sip.foundation.core.declarative.scenario.IntegrationScenarioBase;
 import java.util.Optional;
+import org.apache.camel.Exchange;
 import org.apache.camel.builder.DataFormatClause;
 import org.apache.camel.builder.EndpointProducerBuilder;
 import org.apache.camel.builder.endpoint.StaticEndpointBuilders;
-import org.apache.camel.model.RouteDefinition;
 import org.apache.camel.model.rest.RestBindingMode;
 import org.apache.camel.model.rest.RestDefinition;
 import org.springframework.context.annotation.Bean;
@@ -70,16 +68,7 @@ public class MappingAdapter {
       integrationScenario = MapDomainModelsScenario.ID,
       requestModel = BackendResourceRequest.class)
   @UseRequestModelMapper(BackendTypes.BackendRequestModelMapper.class)
-  public class LoggerConsumerWithReponse extends GenericOutboundConnectorBase {
-
-    @Override
-    @Deprecated
-    protected Orchestrator<ConnectorOrchestrationInfo> defineTransformationOrchestrator() {
-      ConnectorOrchestrator orchestrator =
-          (ConnectorOrchestrator) super.defineTransformationOrchestrator();
-      orchestrator.setResponseRouteTransformer(this::defineResponseRoute);
-      return orchestrator;
-    }
+  public class LoggerConsumerWithResponse extends GenericOutboundConnectorBase {
 
     @Override
     protected Optional<MarshallerDefinition> defineRequestMarshalling() {
@@ -93,16 +82,15 @@ public class MappingAdapter {
               unmarshaller -> unmarshaller.json(BackendResourceRequest.class)));
     }
 
-    protected void defineResponseRoute(final RouteDefinition definition) {
+    @ResponseProcessor
+    public ResourceResponse defineResponseRoute(Exchange exchange) {
       // manually returning the test response
-      definition.setBody(
-          exchange ->
-              ResourceResponse.builder()
-                  .resourceType(
-                      exchange.getIn().getBody(BackendResourceRequest.class).getResourceTypeName())
-                  .resourceName("TEST")
-                  .id(exchange.getIn().getBody(BackendResourceRequest.class).getId())
-                  .build());
+      return ResourceResponse.builder()
+          .resourceType(
+              exchange.getIn().getBody(BackendResourceRequest.class).getResourceTypeName())
+          .resourceName("TEST")
+          .id(exchange.getIn().getBody(BackendResourceRequest.class).getId())
+          .build();
     }
 
     @Override

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/declarative/connector/ConnectorBaseTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/declarative/connector/ConnectorBaseTest.java
@@ -1,11 +1,16 @@
 package de.ikor.sip.foundation.core.declarative.connector;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import de.ikor.sip.foundation.core.declarative.annonation.OutboundConnector;
+import de.ikor.sip.foundation.core.declarative.annonation.UseRequestModelMapper;
+import de.ikor.sip.foundation.core.declarative.annonation.UseResponseModelMapper;
+import de.ikor.sip.foundation.core.declarative.model.ModelMapper;
 import de.ikor.sip.foundation.core.declarative.orchestration.Orchestrator;
 import de.ikor.sip.foundation.core.declarative.orchestration.connector.ConnectorOrchestrationInfo;
 import de.ikor.sip.foundation.core.declarative.orchestration.connector.ConnectorOrchestrator;
+import de.ikor.sip.foundation.core.util.exception.SIPFrameworkInitializationException;
 import org.apache.camel.builder.EndpointProducerBuilder;
 import org.apache.camel.builder.endpoint.StaticEndpointBuilders;
 import org.apache.camel.model.RouteDefinition;
@@ -27,11 +32,70 @@ class ConnectorBaseTest {
         .isNotNull();
   }
 
+  @Test
+  void When_defineTransformationOrchestrator_With_ForbiddenTransformer_Expect_Exception() {
+    // arrange
+    ConnectorWithRequestMapperAndTransformer testConnectorRequest =
+        new ConnectorWithRequestMapperAndTransformer();
+    ConnectorWithResponseMapperAndTransformer testConnectorResponse =
+        new ConnectorWithResponseMapperAndTransformer();
+
+    // act + assert
+    assertThatThrownBy(() -> testConnectorRequest.getOrchestrator())
+        .isInstanceOf(SIPFrameworkInitializationException.class);
+    assertThatThrownBy(() -> testConnectorResponse.getOrchestrator())
+        .isInstanceOf(SIPFrameworkInitializationException.class);
+  }
+
   @OutboundConnector(
       connectorGroup = "group",
       integrationScenario = "scenario",
       requestModel = Object.class)
   class TestConnector extends GenericOutboundConnectorBase {
+    @Override
+    protected EndpointProducerBuilder defineOutgoingEndpoint() {
+      return StaticEndpointBuilders.log("log");
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    protected Orchestrator<ConnectorOrchestrationInfo> defineTransformationOrchestrator() {
+      return ConnectorOrchestrator.forConnector(this).setRequestRouteTransformer(this::setRequest);
+    }
+
+    private void setRequest(RouteDefinition routeDefinition) {
+      routeDefinition.log("log");
+    }
+  }
+
+  @OutboundConnector(
+      connectorGroup = "group",
+      integrationScenario = "scenario",
+      requestModel = Object.class)
+  @UseRequestModelMapper(ModelMapper.class)
+  class ConnectorWithRequestMapperAndTransformer extends GenericOutboundConnectorBase {
+    @Override
+    protected EndpointProducerBuilder defineOutgoingEndpoint() {
+      return StaticEndpointBuilders.log("log");
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    protected Orchestrator<ConnectorOrchestrationInfo> defineTransformationOrchestrator() {
+      return ConnectorOrchestrator.forConnector(this).setRequestRouteTransformer(this::setRequest);
+    }
+
+    private void setRequest(RouteDefinition routeDefinition) {
+      routeDefinition.log("log");
+    }
+  }
+
+  @OutboundConnector(
+      connectorGroup = "group",
+      integrationScenario = "scenario",
+      requestModel = Object.class)
+  @UseResponseModelMapper(ModelMapper.class)
+  class ConnectorWithResponseMapperAndTransformer extends GenericOutboundConnectorBase {
     @Override
     protected EndpointProducerBuilder defineOutgoingEndpoint() {
       return StaticEndpointBuilders.log("log");

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/declarative/connector/ConnectorBaseTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/declarative/connector/ConnectorBaseTest.java
@@ -1,0 +1,43 @@
+package de.ikor.sip.foundation.core.declarative.connector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.ikor.sip.foundation.core.declarative.annonation.OutboundConnector;
+import de.ikor.sip.foundation.core.declarative.orchestration.Orchestrator;
+import de.ikor.sip.foundation.core.declarative.orchestration.connector.ConnectorOrchestrationInfo;
+import org.apache.camel.builder.EndpointProducerBuilder;
+import org.apache.camel.builder.endpoint.StaticEndpointBuilders;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class ConnectorBaseTest {
+
+  @Test
+  void When_defineTransformationOrchestrator_Expect_Orchestrator() {
+    // arrange
+    TestConnector testConnector = new TestConnector();
+
+    // act + assert
+    assertThat(ReflectionTestUtils.getField(testConnector, "modelTransformationOrchestrator"))
+        .isNull();
+    assertThat(testConnector.getOrchestrator()).isNotNull();
+    assertThat(ReflectionTestUtils.getField(testConnector, "modelTransformationOrchestrator"))
+        .isNotNull();
+  }
+
+  @OutboundConnector(
+      connectorGroup = "group",
+      integrationScenario = "scenario",
+      requestModel = Object.class)
+  public class TestConnector extends GenericOutboundConnectorBase {
+    @Override
+    protected EndpointProducerBuilder defineOutgoingEndpoint() {
+      return StaticEndpointBuilders.log("log");
+    }
+
+    @Override
+    protected Orchestrator<ConnectorOrchestrationInfo> defineTransformationOrchestrator() {
+      return super.defineTransformationOrchestrator();
+    }
+  }
+}

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/declarative/connector/ConnectorBaseTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/declarative/connector/ConnectorBaseTest.java
@@ -5,8 +5,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import de.ikor.sip.foundation.core.declarative.annonation.OutboundConnector;
 import de.ikor.sip.foundation.core.declarative.orchestration.Orchestrator;
 import de.ikor.sip.foundation.core.declarative.orchestration.connector.ConnectorOrchestrationInfo;
+import de.ikor.sip.foundation.core.declarative.orchestration.connector.ConnectorOrchestrator;
 import org.apache.camel.builder.EndpointProducerBuilder;
 import org.apache.camel.builder.endpoint.StaticEndpointBuilders;
+import org.apache.camel.model.RouteDefinition;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -29,15 +31,20 @@ class ConnectorBaseTest {
       connectorGroup = "group",
       integrationScenario = "scenario",
       requestModel = Object.class)
-  public class TestConnector extends GenericOutboundConnectorBase {
+  class TestConnector extends GenericOutboundConnectorBase {
     @Override
     protected EndpointProducerBuilder defineOutgoingEndpoint() {
       return StaticEndpointBuilders.log("log");
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     protected Orchestrator<ConnectorOrchestrationInfo> defineTransformationOrchestrator() {
-      return super.defineTransformationOrchestrator();
+      return ConnectorOrchestrator.forConnector(this).setRequestRouteTransformer(this::setRequest);
+    }
+
+    private void setRequest(RouteDefinition routeDefinition) {
+      routeDefinition.log("log");
     }
   }
 }

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/declarative/utils/DeclarativeHelperTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/declarative/utils/DeclarativeHelperTest.java
@@ -34,7 +34,8 @@ class DeclarativeHelperTest {
   @Test
   void WHEN_createMapperWithoutNoArgConstructor_THEN_throwSIPException() {
 
-    assertThatThrownBy(() -> DeclarativeHelper.createMapperInstance(NoArgsConstructorMapper.class))
+    assertThatThrownBy(
+            () -> DeclarativeHelper.createMapperInstance(null, NoArgsConstructorMapper.class))
         .isInstanceOf(SIPFrameworkInitializationException.class)
         .hasMessage(
             "Mapper %s needs to have a no-arg constructor, please define one.",
@@ -45,7 +46,9 @@ class DeclarativeHelperTest {
   void WHEN_createMapperWhichThrowsError_THEN_throwSIPExceptionWhichWrapsRuntimeException() {
 
     assertThatThrownBy(
-            () -> DeclarativeHelper.createMapperInstance(ExceptionThrowingConstructorMapper.class))
+            () ->
+                DeclarativeHelper.createMapperInstance(
+                    null, ExceptionThrowingConstructorMapper.class))
         .isInstanceOf(SIPFrameworkInitializationException.class)
         .hasMessage(
             "SIP couldn't create a Mapper %s.", ExceptionThrowingConstructorMapper.class.getName())


### PR DESCRIPTION
# Description

Use mapper spring bean, if it exists, for request and response transformer annotations in connector, otherwise create new mapper instances.

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing (regression) unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
