### PR TITLE
Throw exception when response handler is used in no response scenario

### DIFF
--- a/changelogs/feature/no_response_in_scenario_orchestration.json
+++ b/changelogs/feature/no_response_in_scenario_orchestration.json
@@ -1,0 +1,5 @@
+{
+  "author": "Nemikor",
+  "pullrequestId": "276",
+  "message": "Prevent using response handing in scenario orchestration when no response model is defined in the scenario."
+}

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/orchestration/scenario/dsl/CallScenarioConsumerBaseDefinition.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/orchestration/scenario/dsl/CallScenarioConsumerBaseDefinition.java
@@ -10,9 +10,9 @@ import lombok.Getter;
 public abstract sealed class CallScenarioConsumerBaseDefinition<
         S extends CallScenarioConsumerBaseDefinition<S, R, M>, R, M>
     extends ScenarioDslDefinitionBase<S, R, M> implements CallableWithinProviderDefinition
-    permits CallScenarioConsumerCatchAllDefinition,
-        CallScenarioConsumerByClassDefinition,
-        CallScenarioConsumerByConnectorIdDefinition {
+    permits CallScenarioConsumerByClassDefinition,
+        CallScenarioConsumerByConnectorIdDefinition,
+        CallScenarioConsumerCatchAllDefinition {
 
   @Getter(AccessLevel.PACKAGE)
   private Optional<ScenarioStepRequestExtractor<M>> requestPreparation = Optional.empty();

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/orchestration/scenario/dsl/CallScenarioConsumerBaseNoResponseDefinition.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/orchestration/scenario/dsl/CallScenarioConsumerBaseNoResponseDefinition.java
@@ -1,0 +1,33 @@
+package de.ikor.sip.foundation.core.declarative.orchestration.scenario.dsl;
+
+import de.ikor.sip.foundation.core.declarative.scenario.IntegrationScenarioConsumerDefinition;
+import de.ikor.sip.foundation.core.declarative.scenario.IntegrationScenarioDefinition;
+import de.ikor.sip.foundation.core.util.exception.SIPFrameworkInitializationException;
+
+/**
+ * DSL class for calling a scenario consumer specified by it's class for scenarios without response
+ */
+public final class CallScenarioConsumerBaseNoResponseDefinition<R, M>
+    extends CallScenarioConsumerByClassDefinition<R, M> {
+
+  CallScenarioConsumerBaseNoResponseDefinition(
+      R dslReturnDefinition,
+      IntegrationScenarioDefinition integrationScenario,
+      Class<? extends IntegrationScenarioConsumerDefinition> consumerClass) {
+    super(dslReturnDefinition, integrationScenario, consumerClass);
+  }
+
+  @Override
+  public R andHandleResponse(ScenarioStepResponseConsumer<M> responseConsumer) {
+    throw SIPFrameworkInitializationException.init(
+        "Integration Scenario %s does not have a response model defined, using response handler is not intended.",
+        getIntegrationScenario().getId());
+  }
+
+  @Override
+  public R andAggregateResponse(final ScenarioStepResponseAggregator<M> responseAggregator) {
+    throw SIPFrameworkInitializationException.init(
+        "Integration Scenario %s does not have a response model defined, using aggregate response is not intended.",
+        getIntegrationScenario().getId());
+  }
+}

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/orchestration/scenario/dsl/CallScenarioConsumerByClassDefinition.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/orchestration/scenario/dsl/CallScenarioConsumerByClassDefinition.java
@@ -6,8 +6,9 @@ import lombok.AccessLevel;
 import lombok.Getter;
 
 /** DSL class for calling a scenario consumer specified by it's class */
-public final class CallScenarioConsumerByClassDefinition<R, M>
-    extends CallScenarioConsumerBaseDefinition<CallScenarioConsumerByClassDefinition<R, M>, R, M> {
+public sealed class CallScenarioConsumerByClassDefinition<R, M>
+    extends CallScenarioConsumerBaseDefinition<CallScenarioConsumerByClassDefinition<R, M>, R, M>
+    permits CallScenarioConsumerBaseNoResponseDefinition {
 
   @Getter(AccessLevel.PACKAGE)
   private final Class<? extends IntegrationScenarioConsumerDefinition> consumerClass;

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/orchestration/scenario/dsl/ScenarioConsumerCallsDelegate.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/orchestration/scenario/dsl/ScenarioConsumerCallsDelegate.java
@@ -35,9 +35,16 @@ final class ScenarioConsumerCallsDelegate<S extends ScenarioConsumerCalls<S, R, 
   @Override
   public CallScenarioConsumerByClassDefinition<S, M> callScenarioConsumer(
       final Class<? extends IntegrationScenarioConsumerDefinition> consumerClass) {
-    final CallScenarioConsumerByClassDefinition<S, M> def =
+    final CallScenarioConsumerByClassDefinition<S, M> consumerByClassDefinition =
         new CallScenarioConsumerByClassDefinition<>(
             definitionNode, integrationScenario, consumerClass);
+    final CallScenarioConsumerBaseNoResponseDefinition<S, M> noResponseDefinition =
+        new CallScenarioConsumerBaseNoResponseDefinition<>(
+            definitionNode, integrationScenario, consumerClass);
+    var def =
+        integrationScenario.getResponseModelClass().isPresent()
+            ? consumerByClassDefinition
+            : noResponseDefinition;
     consumerDefinitions.add(def);
     return def;
   }

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/declarative/orchestration/scenario/dsl/ScenarioConsumerCallsDelegateTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/declarative/orchestration/scenario/dsl/ScenarioConsumerCallsDelegateTest.java
@@ -1,0 +1,29 @@
+package de.ikor.sip.foundation.core.declarative.orchestration.scenario.dsl;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import de.ikor.sip.foundation.core.declarative.annonation.IntegrationScenario;
+import de.ikor.sip.foundation.core.declarative.connector.GenericOutboundConnectorBase;
+import de.ikor.sip.foundation.core.declarative.scenario.IntegrationScenarioBase;
+import de.ikor.sip.foundation.core.util.exception.SIPFrameworkInitializationException;
+import org.junit.jupiter.api.Test;
+
+class ScenarioConsumerCallsDelegateTest {
+
+  @IntegrationScenario(scenarioId = "test", requestModel = String.class)
+  class TestScenario extends IntegrationScenarioBase {}
+
+  @Test
+  void
+      When_NoResponseInScenario_With_ResponseHandlerInOrchestration_Then_ThrowInitializationException() {
+    var s =
+        new CallScenarioConsumerBaseNoResponseDefinition(
+            mock(), new TestScenario(), GenericOutboundConnectorBase.class);
+
+    assertThatThrownBy(() -> s.andHandleResponse((a, b) -> {}))
+        .isInstanceOf(SIPFrameworkInitializationException.class)
+        .hasMessageContaining(
+            "Integration Scenario test does not have a response model defined, using response handler is not intended.");
+  }
+}

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/declarative/orchestration/scenario/dsl/ScenarioConsumerCallsDelegateTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/declarative/orchestration/scenario/dsl/ScenarioConsumerCallsDelegateTest.java
@@ -26,4 +26,17 @@ class ScenarioConsumerCallsDelegateTest {
         .hasMessageContaining(
             "Integration Scenario test does not have a response model defined, using response handler is not intended.");
   }
+
+  @Test
+  void
+      When_NoResponseInScenario_With_AggregationInOrchestration_Then_ThrowInitializationException() {
+    var s =
+        new CallScenarioConsumerBaseNoResponseDefinition(
+            mock(), new TestScenario(), GenericOutboundConnectorBase.class);
+
+    assertThatThrownBy(() -> s.andAggregateResponse((a, b) -> a))
+        .isInstanceOf(SIPFrameworkInitializationException.class)
+        .hasMessageContaining(
+            "Integration Scenario test does not have a response model defined, using aggregate response is not intended.");
+  }
 }


### PR DESCRIPTION
# Description

Throw exception when response handler is used in orchestration of a scenario with no response model defined

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SIP Framework version(s):
* Other configuration:

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing (regression) unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
