### PR TITLE
Reregister routes with correct ids in RoutesRegistry

### DIFF
--- a/changelogs/bugfix/fix_route_id_for_rest_inbound_connector.json
+++ b/changelogs/bugfix/fix_route_id_for_rest_inbound_connector.json
@@ -1,0 +1,5 @@
+{
+  "author": "Nemikor",
+  "pullrequestId": "282",
+  "message": "Fix an issue where incorrect route id and connector id was registered for REST inbound connectors."
+}

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/RoutesRegistry.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/RoutesRegistry.java
@@ -314,4 +314,13 @@ public class RoutesRegistry extends SimpleEventNotifierSupport {
         ? expression.toString()
         : String.format("%s-%s", processorName, counter);
   }
+
+  public void updateRouteId(String targetToBase, String routePath) {
+    var connector = connectorForRouteIdRegister.remove(targetToBase);
+    connectorForRouteIdRegister.put(routePath, connector);
+    routeIdsForConnectorRegister.remove(connector);
+    routeIdsForConnectorRegister.put(connector, routePath);
+    var role = roleForRouteIdRegister.remove(targetToBase);
+    roleForRouteIdRegister.put(routePath, role);
+  }
 }

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/RestInboundConnectorBase.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/RestInboundConnectorBase.java
@@ -41,6 +41,7 @@ public abstract class RestInboundConnectorBase extends InboundConnectorBase
               RouteRole.EXTERNAL_ENDPOINT, this, "-rest-dsl-", ++endpointCounter));
       String routePath = targetToBase + "-rest-dsl-" + endpointCounter;
       ToDefinition toDefinition = new ToDefinition("direct:" + routePath);
+      routeRegistry.updateRouteId(targetToBase, routePath);
       verb.setTo(toDefinition);
       routeToPaths.add(routePath);
     }


### PR DESCRIPTION
# Description

Register correct route id in RoutesRegistry when building REST Inbound connectors.
This will fix an issue where connectorId could not be used in test kit for rest connectors.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SIP Framework version(s):
* Other configuration:

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing (regression) unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
