### PR TITLE
REST Inbound connectors without multiple verbs

### DIFF
--- a/changelogs/bugfix/forbid_multiple_rest_dsl_verbs.json
+++ b/changelogs/bugfix/forbid_multiple_rest_dsl_verbs.json
@@ -1,0 +1,5 @@
+{
+  "author": "Nemikor",
+  "pullrequestId": "284",
+  "message": "Forbid usage of multiple REST DSL verbs for different HTTP methods in a single Rest inbound connector."
+}

--- a/docs-snapshot/framework_version_upgrade.md
+++ b/docs-snapshot/framework_version_upgrade.md
@@ -1,0 +1,200 @@
+# SIP Framework version upgrade
+
+[TOC]
+
+## Upgrade from 3.6.1 to x.y.z
+
+Building REST inbound connectors was changed. 
+Usage of multiple HTTP methods in REST DSL of a single connector is no longer allowed.
+REST Connectors which contain this should be split into their own connector implementations.
+This change will not affect how the adapter behaves.
+
+**Note:** Unique connector ID should be assigned to each new connector, 
+since the automatically generated one may be duplicated.
+
+## Upgrade from 3.5.0 to 3.6.0
+
+This version contains upgrades to major libraries used by the framework.
+There is a possibility that they may lead to some changes.
+
+Please use the following Apache Camel guide if necessary: https://camel.apache.org/manual/camel-4x-upgrade-guide.html
+
+## Upgrade from 3.4.0 to 3.5.0
+
+This is a quality of life and bugfix update, it shouldn't introduce any breaking issues.
+
+## Upgrade from 3.3.0 to 3.4.0
+
+Version 3.4.0 allows fine-grained configuration and exception handling for connectors. 
+If an adapter contains global configuration which was added directly with **RouteConfigurationBuilder**, 
+it will no longer apply to connectors.
+It should be refactored and provided via **ConfigurationDefinition**.
+
+**Note:** When it comes to process orchestration global configuration will still be applicable.
+
+**Deprecation Notice**
+
+The `defineTransformationOrchestrator` method from **ConnectorBase** class is marked as deprecated as of version 3.4.0. 
+This method may be removed in future versions.
+It is recommended to migrate to new **Connector Processors** in all connectors.
+
+## Upgrade from 3.2.0 to 3.3.0
+
+This is mostly a dependencies update and bugfix version, so it's shouldn't introduce any braking changes. 
+However, in the previous version, Integration Scenario model validation was triggered conditionally
+depending on the presence of Connector's response model (instead of Integration Scenario's).
+This has been changed, and the response transformation in the connector is now triggered unconditionally as well.
+
+A runtime **validation** error will occur if an Adapter relied on that condition and **didn't conform** to Scenario's **domain model**.
+
+## Upgrade from 3.1.0 to 3.2.0
+Version 3.2.0 introduces changes in dependencies - most notably Spring 6, Apache Camel 4 and CXF 4. 
+There should be no breaking changes in this release. If the adapter developers relied on deprecated features from underlying frameworks then some changes are necessary but those should be fixed on case-by-case basis.
+
+Upgrade guide for specific use-cases:
+* Adapters using **SOAP** Connectors
+
+From adapter pom.xml file remove this plugin:
+```xml
+<plugin>
+  <groupId>de.codecentric</groupId>
+  <artifactId>cxf-spring-boot-starter-maven-plugin</artifactId>
+...
+</plugin>
+```
+and change it to:
+```xml
+<plugin>
+  <groupId>org.apache.cxf</groupId>
+  <artifactId>cxf-codegen-plugin</artifactId>
+</plugin>
+```
+Plugin is now managed in the parent pom so no further configuration is necessary. It is a standard CXF plugin and adapter developers can customize its behaviour if needed.
+
+
+* Adapters redefining **Spring Security**:
+If the adapter has redefined Spring Security configuration, exclusion of SIP Security was necessary:
+For example: 
+```java
+@SIPIntegrationAdapter(exclude = SIPSecurityAutoConfiguration.class)
+```
+That should no longer be necessary, SIP has upgraded to Spring Security 6 and should work with specific behaviour redefined in the adapter.
+
+
+## Upgrade from 1.0.0 to 2.0.0
+
+The following text represents the complete guide how to update SIP framework version in your adapter from version 
+`1.0.0` to `2.0.0`.
+
+In case adapter is generated with archetype of `2.0.0` framework version, following steps are not necessary. To insure
+your adapter uses all functionalities, the following changes have to be done manually. Please follow the guide
+step by step.
+
+Single lines necessary for updating are marked with `update` comment.
+
+First step is to update the parent field `version` in project root `pom.xml` file:
+
+```xml
+<parent>
+    <groupId>de.ikor.sip.foundation</groupId>
+    <artifactId>sip-framework</artifactId>
+    <version>2.0.0</version>    <!-- update -->
+    <relativePath/>
+</parent>
+```
+
+In the same file, profile fields `id` and `maxJdkVersion` should be updated to java version 11.
+
+```xml
+<profiles>
+    <profile>
+        <id>enforce-java-11</id>                <!-- update -->
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.0.0-M3</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>extra-enforcer-rules</artifactId>
+                            <version>1.3</version>
+                        </dependency>
+                    </dependencies>
+                    <executions>
+                        <execution>
+                            <id>enforce-bytecode-version</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <enforceBytecodeVersion>
+                                        <maxJdkVersion>11</maxJdkVersion>   <!-- update -->
+                                    </enforceBytecodeVersion>
+                                </rules>
+                                <fail>true</fail>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </build>
+    </profile>
+</profiles>
+```
+
+Next step is to update `pom.xml` file in adapter's application module. Change the parent field `version`:
+
+```xml
+<parent>
+    <groupId>de.ikor.sip.foundation</groupId>
+    <artifactId>sip-starter-parent</artifactId>
+    <version>2.0.0</version>    <!-- update -->
+    <relativePath/>
+</parent>
+```
+
+In the same file, `spring-boot-maven-plugin` must be modified. Add goal `build-info` and it's additional
+configuration. Simply copy the lines marked with comment `update` and add them to your code in a proper place:
+
+```xml
+<plugin>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-maven-plugin</artifactId>
+    <configuration>
+        <fork>false</fork>
+        <skip>false</skip>
+    </configuration>
+    <executions>
+        <execution>
+            <goals>
+                <goal>repackage</goal>
+                <goal>build-info</goal>     <!-- update -->
+            </goals>
+            <configuration>                         <!-- update -->
+                <additionalProperties>                  <!-- update -->
+                    <sipFrameworkVersion>2.0.0</sipFrameworkVersion>    <!-- update -->
+                </additionalProperties>                 <!-- update -->
+            </configuration>                        <!-- update -->
+        </execution>
+    </executions>
+</plugin>
+```
+
+Newer version requires moving your markdown files in adapter's application module under `main/resources/documents` directory.
+Furthermore, it is strictly required to create `documents` folder and to keep markdown files inside, so the
+[markdown files API](./core.md#sip-details-in-actuator-info-endpoint) can work properly.
+
+If you intend to use SIP Test Kit, you should add `application.yml` in your application module `src/test/resources`
+directory with test profile configured:
+
+```yaml
+spring:
+  profiles:
+    active: test
+```
+
+Additionally `logback-test.xml` should be added in the same test directory. You can find the content of this file 
+[here](../sip-archetype/src/main/resources/archetype-resources/__rootArtifactId__-application/src/test/resources/logback-test.xml).

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/AdapterBuilder.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/AdapterBuilder.java
@@ -176,11 +176,10 @@ public final class AdapterBuilder extends RouteBuilder {
 
     // Channel all inbound camel endpoint routes to the orchestration route
     final var endpointDefinitionType = inboundConnector.getEndpointDefinitionTypeClass();
-    List<String> directRoutes =
-        inboundConnector.defineInboundEndpoints(
-            resolveConnectorDefinitionType(endpointDefinitionType),
-            requestOrchestrationRouteId,
-            routesRegistry);
+    inboundConnector.defineInboundEndpoints(
+        resolveConnectorDefinitionType(endpointDefinitionType),
+        requestOrchestrationRouteId,
+        routesRegistry);
 
     // Build scenario handoff and response-route
     String routeConfigurationIds =
@@ -218,26 +217,24 @@ public final class AdapterBuilder extends RouteBuilder {
     handoffRouteDefinition.to(StaticEndpointBuilders.direct(responseOrchestrationRouteId));
 
     // Build orchestration route(s) to/from scenario
+    final var requestRouteDefinition =
+        from(StaticEndpointBuilders.direct(requestOrchestrationRouteId))
+            .routeId(requestOrchestrationRouteId)
+            .routeConfigurationId(routeConfigurationIds);
+    appendOnException(inboundConnector, requestRouteDefinition);
     final RouteDefinition responseRouteDefinition =
         from(StaticEndpointBuilders.direct(responseOrchestrationRouteId))
             .routeId(responseOrchestrationRouteId)
             .routeConfigurationId(routeConfigurationIds);
     appendOnException(inboundConnector, responseRouteDefinition);
-    directRoutes.forEach(
-        route -> {
-          final var requestRouteDefinition =
-              from(StaticEndpointBuilders.direct(route))
-                  .routeId(route)
-                  .routeConfigurationId(routeConfigurationIds);
-          appendOnException(inboundConnector, requestRouteDefinition);
-          var orchestrationInfo =
-              new OrchestrationRoutes(requestRouteDefinition, Optional.of(responseRouteDefinition));
 
-          if (inboundConnector.getOrchestrator().canOrchestrate(orchestrationInfo)) {
-            inboundConnector.getOrchestrator().doOrchestrate(orchestrationInfo);
-          }
-          requestRouteDefinition.to(StaticEndpointBuilders.direct(scenarioHandoffRouteId));
-        });
+    var orchestrationInfo =
+        new OrchestrationRoutes(requestRouteDefinition, Optional.of(responseRouteDefinition));
+
+    if (inboundConnector.getOrchestrator().canOrchestrate(orchestrationInfo)) {
+      inboundConnector.getOrchestrator().doOrchestrate(orchestrationInfo);
+    }
+    requestRouteDefinition.to(StaticEndpointBuilders.direct(scenarioHandoffRouteId));
   }
 
   private void buildOutboundConnector(

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/GenericInboundConnectorBase.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/GenericInboundConnectorBase.java
@@ -7,7 +7,6 @@ import de.ikor.sip.foundation.core.declarative.RoutesRegistry;
 import de.ikor.sip.foundation.core.declarative.annonation.InboundConnector;
 import de.ikor.sip.foundation.core.declarative.model.MarshallerDefinition;
 import de.ikor.sip.foundation.core.declarative.model.UnmarshallerDefinition;
-import java.util.List;
 import java.util.Optional;
 import org.apache.camel.builder.EndpointConsumerBuilder;
 import org.apache.camel.builder.endpoint.StaticEndpointBuilders;
@@ -28,7 +27,7 @@ public abstract class GenericInboundConnectorBase extends InboundConnectorBase
     implements InboundConnectorDefinition<RoutesDefinition> {
 
   @Override
-  public final List<String> defineInboundEndpoints(
+  public final void defineInboundEndpoints(
       final RoutesDefinition definition,
       final String targetToBase,
       final RoutesRegistry routeRegistry) {
@@ -46,7 +45,6 @@ public abstract class GenericInboundConnectorBase extends InboundConnectorBase
     defineRequestUnmarshalling().ifPresent(unmarshaller -> unmarshaller.accept(routeDef));
     routeDef.to(StaticEndpointBuilders.direct(targetToBase));
     defineResponseMarshalling().ifPresent(marshaller -> marshaller.accept(routeDef));
-    return List.of(targetToBase);
   }
 
   /**

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/InboundConnectorDefinition.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/InboundConnectorDefinition.java
@@ -39,7 +39,7 @@ public non-sealed interface InboundConnectorDefinition<T extends OptionalIdentif
    * @param routeRegistry Route registry that must be used to register routeIds for the inbound
    *     endpoint(s).
    */
-  List<String> defineInboundEndpoints(
+  void defineInboundEndpoints(
       T definition, String targetToBase, RoutesRegistry routeRegistry);
 
   @Override

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/InboundConnectorDefinition.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/InboundConnectorDefinition.java
@@ -2,7 +2,6 @@ package de.ikor.sip.foundation.core.declarative.connector;
 
 import de.ikor.sip.foundation.core.declarative.RoutesRegistry;
 import de.ikor.sip.foundation.core.declarative.scenario.IntegrationScenarioProviderDefinition;
-import java.util.List;
 import org.apache.camel.builder.EndpointProducerBuilder;
 import org.apache.camel.model.OptionalIdentifiedDefinition;
 
@@ -39,8 +38,7 @@ public non-sealed interface InboundConnectorDefinition<T extends OptionalIdentif
    * @param routeRegistry Route registry that must be used to register routeIds for the inbound
    *     endpoint(s).
    */
-  void defineInboundEndpoints(
-      T definition, String targetToBase, RoutesRegistry routeRegistry);
+  void defineInboundEndpoints(T definition, String targetToBase, RoutesRegistry routeRegistry);
 
   @Override
   default ConnectorType getConnectorType() {

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/RestInboundConnectorBase.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/RestInboundConnectorBase.java
@@ -4,9 +4,6 @@ import de.ikor.sip.foundation.core.declarative.RouteRole;
 import de.ikor.sip.foundation.core.declarative.RoutesRegistry;
 import de.ikor.sip.foundation.core.declarative.annonation.InboundConnector;
 import de.ikor.sip.foundation.core.declarative.annotation.rest.ParameterMapping;
-import java.util.ArrayList;
-import java.util.List;
-
 import de.ikor.sip.foundation.core.util.exception.SIPFrameworkInitializationException;
 import org.apache.camel.model.ToDefinition;
 import org.apache.camel.model.rest.RestDefinition;
@@ -35,12 +32,11 @@ public abstract class RestInboundConnectorBase extends InboundConnectorBase
       final RoutesRegistry routeRegistry) {
     var rest = definition.rest();
     configureRest(rest);
-    SIPFrameworkInitializationException.throwIf(rest.getVerbs().size() > 1,
-            "Using multiple REST endpoints in one Inbound connector is not allowed");
+    SIPFrameworkInitializationException.throwIf(
+        rest.getVerbs().size() > 1,
+        "Using multiple REST endpoints in one Inbound connector is not allowed");
     for (VerbDefinition verb : rest.getVerbs()) {
-      verb.setId(
-          routeRegistry.generateRouteIdForConnector(
-              RouteRole.EXTERNAL_ENDPOINT, this));
+      verb.setId(routeRegistry.generateRouteIdForConnector(RouteRole.EXTERNAL_ENDPOINT, this));
       ToDefinition toDefinition = new ToDefinition("direct:" + targetToBase);
       verb.setTo(toDefinition);
     }

--- a/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/RestInboundConnectorBase.java
+++ b/sip-core/src/main/java/de/ikor/sip/foundation/core/declarative/connector/RestInboundConnectorBase.java
@@ -6,6 +6,8 @@ import de.ikor.sip.foundation.core.declarative.annonation.InboundConnector;
 import de.ikor.sip.foundation.core.declarative.annotation.rest.ParameterMapping;
 import java.util.ArrayList;
 import java.util.List;
+
+import de.ikor.sip.foundation.core.util.exception.SIPFrameworkInitializationException;
 import org.apache.camel.model.ToDefinition;
 import org.apache.camel.model.rest.RestDefinition;
 import org.apache.camel.model.rest.RestsDefinition;
@@ -27,24 +29,21 @@ public abstract class RestInboundConnectorBase extends InboundConnectorBase
     implements InboundConnectorDefinition<RestsDefinition> {
 
   @Override
-  public final List<String> defineInboundEndpoints(
+  public final void defineInboundEndpoints(
       final RestsDefinition definition,
       final String targetToBase,
       final RoutesRegistry routeRegistry) {
     var rest = definition.rest();
-    var endpointCounter = 0;
     configureRest(rest);
-    List<String> routeToPaths = new ArrayList<>();
+    SIPFrameworkInitializationException.throwIf(rest.getVerbs().size() > 1,
+            "Using multiple REST endpoints in one Inbound connector is not allowed");
     for (VerbDefinition verb : rest.getVerbs()) {
       verb.setId(
           routeRegistry.generateRouteIdForConnector(
-              RouteRole.EXTERNAL_ENDPOINT, this, "-rest-dsl-", ++endpointCounter));
-      String routePath = targetToBase + "-rest-dsl-" + endpointCounter;
-      ToDefinition toDefinition = new ToDefinition("direct:" + routePath);
+              RouteRole.EXTERNAL_ENDPOINT, this));
+      ToDefinition toDefinition = new ToDefinition("direct:" + targetToBase);
       verb.setTo(toDefinition);
-      routeToPaths.add(routePath);
     }
-    return routeToPaths;
   }
 
   /**

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/apps/declarative/SimpleAdapter.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/apps/declarative/SimpleAdapter.java
@@ -91,20 +91,44 @@ public class SimpleAdapter {
   }
 
   @InboundConnector(
+          connectorId = "PostRestInboundConnectorTestBase",
       connectorGroup = ConnectorGroupSip1.ID,
       integrationScenario = RestDSLScenario.ID,
       requestModel = String.class)
-  public class RestInboundConnectorTestBase extends RestInboundConnectorBase {
+  public class PostRestInboundConnectorTestBase extends RestInboundConnectorBase {
 
     @Override
     protected void configureRest(RestDefinition definition) {
-      definition.bindingMode("off").post("path").type(String.class).get("path");
+      definition.bindingMode("off").post("path").type(String.class);
     }
 
     @Override
     protected Orchestrator<ConnectorOrchestrationInfo> defineTransformationOrchestrator() {
       return ConnectorOrchestrator.forConnector(this)
           .setRequestRouteTransformer(this::defineRequestRoute);
+    }
+
+    protected void defineRequestRoute(final RouteDefinition definition) {
+      definition.setBody(exchange -> "PRODUCED_REST-" + exchange.getIn().getBody(String.class));
+    }
+  }
+
+  @InboundConnector(
+          connectorId = "GetRestInboundConnectorTestBase",
+          connectorGroup = ConnectorGroupSip1.ID,
+          integrationScenario = RestDSLScenario.ID,
+          requestModel = String.class)
+  public class GetRestInboundConnectorTestBase extends RestInboundConnectorBase {
+
+    @Override
+    protected void configureRest(RestDefinition definition) {
+      definition.bindingMode("off").get("path");
+    }
+
+    @Override
+    protected Orchestrator<ConnectorOrchestrationInfo> defineTransformationOrchestrator() {
+      return ConnectorOrchestrator.forConnector(this)
+              .setRequestRouteTransformer(this::defineRequestRoute);
     }
 
     protected void defineRequestRoute(final RouteDefinition definition) {

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/apps/declarative/SimpleAdapter.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/apps/declarative/SimpleAdapter.java
@@ -91,7 +91,7 @@ public class SimpleAdapter {
   }
 
   @InboundConnector(
-          connectorId = "PostRestInboundConnectorTestBase",
+      connectorId = "PostRestInboundConnectorTestBase",
       connectorGroup = ConnectorGroupSip1.ID,
       integrationScenario = RestDSLScenario.ID,
       requestModel = String.class)
@@ -114,10 +114,10 @@ public class SimpleAdapter {
   }
 
   @InboundConnector(
-          connectorId = "GetRestInboundConnectorTestBase",
-          connectorGroup = ConnectorGroupSip1.ID,
-          integrationScenario = RestDSLScenario.ID,
-          requestModel = String.class)
+      connectorId = "GetRestInboundConnectorTestBase",
+      connectorGroup = ConnectorGroupSip1.ID,
+      integrationScenario = RestDSLScenario.ID,
+      requestModel = String.class)
   public class GetRestInboundConnectorTestBase extends RestInboundConnectorBase {
 
     @Override
@@ -128,7 +128,7 @@ public class SimpleAdapter {
     @Override
     protected Orchestrator<ConnectorOrchestrationInfo> defineTransformationOrchestrator() {
       return ConnectorOrchestrator.forConnector(this)
-              .setRequestRouteTransformer(this::defineRequestRoute);
+          .setRequestRouteTransformer(this::defineRequestRoute);
     }
 
     protected void defineRequestRoute(final RouteDefinition definition) {

--- a/sip-core/src/test/java/de/ikor/sip/foundation/core/declarative/DeclarativeDefinitionEndpointTest.java
+++ b/sip-core/src/test/java/de/ikor/sip/foundation/core/declarative/DeclarativeDefinitionEndpointTest.java
@@ -38,7 +38,7 @@ class DeclarativeDefinitionEndpointTest {
 
   private final int CONNECTORGROUPS_IN_TEST_ADAPTER = 2;
   private final int SCENARIOS_IN_TEST_ADAPTER = 2;
-  private final int CONNECTORS_IN_TEST_ADAPTER = 4;
+  private final int CONNECTORS_IN_TEST_ADAPTER = 5;
 
   @Test
   void when_ActuatorGetAdapterDefinitionInfo_then_RetrieveFullAdapterInfo() throws IOException {


### PR DESCRIPTION
# Description

Forbid possibility to add multiple verbs (HTTP methods) in a single REST inbound connector. It resolves issues with processors in connectors.
Reverts how route IDs are created for rest connectors.


## Type of change

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SIP Framework version(s):
* Other configuration:

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing (regression) unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
