### PR TITLE
Disable csrf in soap configuration

### DIFF
--- a/changelogs/bugfix/disable_csrf_soap.json
+++ b/changelogs/bugfix/disable_csrf_soap.json
@@ -1,0 +1,5 @@
+{
+  "author": "Nemikor",
+  "pullrequestId": "285",
+  "message": "Disable CSRF by default in SOAP configuration."
+}

--- a/sip-soap-starter/src/main/resources/sip-soap-default-config.yaml
+++ b/sip-soap-starter/src/main/resources/sip-soap-default-config.yaml
@@ -2,3 +2,7 @@ cxf:
   servlet:
     enabled: true
   path: /soap-ws/
+sip:
+  security:
+    authentication:
+      disable-csrf: true


### PR DESCRIPTION
# Description

Disable csrf in soap configuration by default when using spring security.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing (regression) unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
