### PR TITLE
SecurityFilterChain improvements

### DIFF
--- a/changelogs/bugfix/sip-security-filter-chain-improvement.json
+++ b/changelogs/bugfix/sip-security-filter-chain-improvement.json
@@ -1,0 +1,5 @@
+{
+  "author": "Nemikor",
+  "pullrequestId": "306",
+  "message": "Add HttpSecurity#securityMatcher to default SecurityFilterChain and possibility to define its bean order."
+}

--- a/docs-snapshot/security.md
+++ b/docs-snapshot/security.md
@@ -31,6 +31,31 @@ Note: Spring Security dependency will also be added as a transitive one.
 
 Following description shows SIP Security functionalities and configuration. Valid configuration is needed to be able to properly utilize SIP security, no additional coding is required.
 
+### Common properties
+
+To make SIP Security have smoother compatibility with Spring's SecurityFilterChain the following can be configured:
+
+```yaml
+sip.security:
+  authentication:
+    # Represents the bean order when using Spring's Ordered interface or @Order annotation.
+    # If default SecurityFilterChain is created, this value must be lower that its order.
+    order: 2 
+    # Ant-style matcher patterns passed to HttpSecurity#securityMatcher.
+    matcher-patterns:
+      - /hello/**
+      - /actuator/info
+```
+
+> *Important:*  Do not include the Apache Camel servlet context path (e.g. /adapter) in the matcher patterns.
+> Camel automatically mounts your REST endpoints under the servlet mapping.
+> 
+> For example, given the endpoint:
+>
+> `GET http://localhost:8080/adapter/hello/world`
+> - Correct matcher pattern: "/hello/\**"
+> - Incorrect matcher pattern: "/adapter/hello/\**"
+
 ### SSL
 SSL is by default turned off. It can be activated by turning it on explicitly either on a client or on a sever side.
 

--- a/docs-snapshot/security.md
+++ b/docs-snapshot/security.md
@@ -1,0 +1,157 @@
+# SIP Security
+
+[TOC]
+
+## Introduction
+
+**What is SIP Security?**
+SIP Security is built on top of Spring Security and is trying to ease and streamline the usage of Security related aspects,
+but also add some enterprise grade features which are, from our perspective, quite relevant and helpful.
+
+**Why use it?**
+Nowadays, security is one of the most important topics in every application.
+Implementing code and configuration on top of Spring Security should help you jump-start your adapter development
+(along with the archetype), not waste your time, and enable you to focus on your core tasks - resolving integration problems.
+
+## Installation
+
+Adding the Maven dependency for SIP Security should be enough to boostrap it. For proper configuration please refer to the "Configuration" chapter.
+```xml
+<dependency>
+    <groupId>one.x1f.sip.foundation</groupId>
+    <artifactId>sip-security</artifactId>
+</dependency>
+```
+
+SIP Security dependency is included by default when creating adapter with SIP Archetype.
+
+Note: Spring Security dependency will also be added as a transitive one.
+
+## Configuration
+
+Following description shows SIP Security functionalities and configuration. Valid configuration is needed to be able to properly utilize SIP security, no additional coding is required.
+
+### SSL
+SSL is by default turned off. It can be activated by turning it on explicitly either on a client or on a sever side.
+
+Client SSL is by default using a server certificate. If no server certificate is set a client certificate is mandatory when turning on client SSL.
+
+- Client (our application is consuming APIs using the provided certificate)
+  ```yaml
+  sip.security:
+      ssl:
+          client:
+              enabled: true #true / false (default); if enabled but no other configs are made, server keystore is used as client certificate
+              key-store: classpath:keystore.p12 # possible resource strings are classpath:, file:, http:, _none_
+              key-store-password: password # we recommend to use env_vars or sealed secrets
+              key-store-type: pkcs12 #possible options are pkcs12, jks, jceks
+              key-alias: springboot #the alias of the key to be chosen from the container
+              key-password: password # we recommend to use env_vars or sealed secrets
+  ```
+  To turn off the usage of client SSL check (default):
+  ```yaml
+  sip.security:
+      ssl:
+          client:
+              enabled: false
+  ```
+  The truststore is handled with Java default:
+    - set the cacerts in the runtime accordingly (preferable approach)
+    - for local development you could add any certificate, IntermediateCA, RootCA or complete certificate chain to the 
+      keystore as a trusted certificate (e.g. by importing it with tools like keytool), a possible command could be:
+  `keytool -importcert -file certificate.cer -keystore keystore.jks -alias "Alias"`
+
+- Server (our application is providing APIs using the provided certificate)
+  ```yaml
+  sip.security:
+      ssl:
+          server:
+              key-store: classpath:keystore.p12 # possible resource strings are classpath:, file:, http:, _none_
+              key-store-password: password # we recommend to use env_vars or sealed secrets
+              key-store-type: pkcs12 #possible options are pkcs12, jks, jceks
+              key-alias: springboot #the alias of the key to be chosen from the container
+              key-password: password # we recommend to use env_vars or sealed secrets
+              client-auth: want # Could be: need (client auth is mandatory), want (client auth is is wanted but not 
+              # mandatory) and none (default)
+  ```
+  To turn the usage of the server certificate off:
+  ```yaml
+  sip.security:
+      ssl:
+          enabled: false
+  ```
+
+### Authentication
+Global authentication configuration:
+
+```yaml
+sip.security:
+    authentication:
+        disable-csrf: true
+        ignored-endpoints: #a list of endpoints which are ignored by ALL authenticators based on Spring´s AntPathMatchers implementation
+        - /actuator
+        - /actuator/**
+        - /favicon.ico
+```
+
+#### Definitions
+These are the basic building blocks of authentication mechanism:
+- <u>Extractors</u> -Extract the relevant Token from a HTTP Requests
+    - BasicAuth: Extracts the BasicAuth credentials from the request Header
+    - X509: Extracts the X509 certificate from the request (requires _sip.security.ssl.server.client-auth_ set to _need_ or _want_ - _none_ is by default)
+- <u>Providers</u> - Triggers a Validator to validate a given authentication request
+    - BasicAuth: Takes the extracted basic auth token and uses the given validator from the configuration to validate the token
+    - X509: Takes the extracted X509 token and uses the given validator from the configuration to validate the token
+- <u>Validators</u> - Validates a given token against a provided list of valid user credentials which are provided via configuration
+ 
+  
+#### Examples
+
+- BasicAuth
+  ```yaml
+  sip.security:
+      authentication:
+          auth-providers: #authentication functionality is enabled if valid providers are defined
+              - classname: one.x1f.sip.foundation.security.authentication.basic.SIPBasicAuthAuthenticationProvider
+                ignored-endpoints: #a list of endpoints which are ignored by this specific authenticator based on Spring´s AntPathMatchers implementation
+                  - /actuator/health
+                  - /actuator/env
+                validation:
+                  classname: one.x1f.sip.foundation.security.authentication.basic.SIPBasicAuthFileValidator #FQCN of the validator to be used
+                  file-path: classpath:basic-auth-users.json  # possible resource strings are classpath:, file:, http:, _none_
+  ```
+  Sample file `basic-auth-users.json`:
+  ```json
+  [
+      {"username": "user1", "password": "pw1"},
+      {"username": "anotherUser", "password": "anotherPassword"}
+  ]
+  ```
+- X509 Configuration:
+  ```yaml
+  sip.security:
+      authentication:
+          auth-providers: #authentication functionality is enabled if valid providers are defined
+              - classname: one.x1f.sip.foundation.security.authentication.x509.SIPX509AuthenticationProvider
+                ignored-endpoints: #a list of endpoints which are ignored by this specific authenticator based on Spring´s AntPathMatchers implementation
+                  - /favicon.ico
+                  - /actuator/env
+                validation:
+                  classname: one.x1f.sip.foundation.security.authentication.x509.SIPX509FileValidator #FQCN of the validator to be used
+                  file-path: classpath:client-certs.acl  # possible resource strings are classpath:, file:, http:, _none_
+  ```
+  Sample file `client-certs.acl`:
+  ```text
+  CN=Full Name, EMAILADDRESS=name@domain.de, O=[*], C=DE
+  CN=Full Name2, EMAILADDRESS=name2@domain.de, O=[*], C=DE
+  ```
+
+### Additional information
+
+- *ACL* in the context of SIP Security and X509 is our implementation of an *Access Control List*.
+  `SIPX509FileValidator` uses a given .acl file to grant access to respective users. This SIP specific feature is not related to [Spring Security´s ACL](https://docs.spring.io/spring-security/site/docs/3.0.x/reference/domain-acls.html) implementation.
+  The high-level intention is to limit the access to the provided API. If this feature is used client certificates are needed.
+
+- To set the password for configuration value `sip.security.ssl.server.key-store-password` by environment variable you can do the following in your (bash) shell
+  (Spring will automatically find the correct variable and set the value):
+  > `export SIP_SECURITY_SSL_SERVER_KEY_STORE_PASSWORD="password"`

--- a/sip-integration-starter/pom.xml
+++ b/sip-integration-starter/pom.xml
@@ -23,10 +23,6 @@
         </dependency>
         <dependency>
             <groupId>one.x1f.sip.foundation</groupId>
-            <artifactId>sip-security</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>one.x1f.sip.foundation</groupId>
             <artifactId>sip-test-kit</artifactId>
         </dependency>
 

--- a/sip-security/src/main/java/one/x1f/sip/foundation/security/config/OrderedSecurityFilterChain.java
+++ b/sip-security/src/main/java/one/x1f/sip/foundation/security/config/OrderedSecurityFilterChain.java
@@ -1,0 +1,34 @@
+package one.x1f.sip.foundation.security.config;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.Ordered;
+import org.springframework.security.web.SecurityFilterChain;
+
+import java.util.List;
+
+public class OrderedSecurityFilterChain implements SecurityFilterChain, Ordered {
+    private final int order;
+    private final SecurityFilterChain delegate;
+
+    public OrderedSecurityFilterChain(int order, SecurityFilterChain delegate) {
+        this.order = order;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public int getOrder() {
+        return order;
+    }
+
+    @Override
+    public boolean matches(HttpServletRequest request) {
+        return delegate.matches(request);
+    }
+
+    @Override
+    public List<Filter> getFilters() {
+        return delegate.getFilters();
+    }
+}
+

--- a/sip-security/src/main/java/one/x1f/sip/foundation/security/config/OrderedSecurityFilterChain.java
+++ b/sip-security/src/main/java/one/x1f/sip/foundation/security/config/OrderedSecurityFilterChain.java
@@ -2,33 +2,31 @@ package one.x1f.sip.foundation.security.config;
 
 import jakarta.servlet.Filter;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 import org.springframework.core.Ordered;
 import org.springframework.security.web.SecurityFilterChain;
 
-import java.util.List;
-
 public class OrderedSecurityFilterChain implements SecurityFilterChain, Ordered {
-    private final int order;
-    private final SecurityFilterChain delegate;
+  private final int order;
+  private final SecurityFilterChain delegate;
 
-    public OrderedSecurityFilterChain(int order, SecurityFilterChain delegate) {
-        this.order = order;
-        this.delegate = delegate;
-    }
+  public OrderedSecurityFilterChain(int order, SecurityFilterChain delegate) {
+    this.order = order;
+    this.delegate = delegate;
+  }
 
-    @Override
-    public int getOrder() {
-        return order;
-    }
+  @Override
+  public int getOrder() {
+    return order;
+  }
 
-    @Override
-    public boolean matches(HttpServletRequest request) {
-        return delegate.matches(request);
-    }
+  @Override
+  public boolean matches(HttpServletRequest request) {
+    return delegate.matches(request);
+  }
 
-    @Override
-    public List<Filter> getFilters() {
-        return delegate.getFilters();
-    }
+  @Override
+  public List<Filter> getFilters() {
+    return delegate.getFilters();
+  }
 }
-

--- a/sip-security/src/main/java/one/x1f/sip/foundation/security/config/SecurityConfig.java
+++ b/sip-security/src/main/java/one/x1f/sip/foundation/security/config/SecurityConfig.java
@@ -113,6 +113,7 @@ public class SecurityConfig {
    */
   @Bean
   public SecurityFilterChain sipDefaultSecurityFilterChain(HttpSecurity http) throws Exception {
+    http.securityMatcher(config.getMatcherPatterns());
     // disable sessions completely
     http.sessionManagement(
         session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
@@ -129,7 +130,7 @@ public class SecurityConfig {
             authorizationManagerRequestMatcherRegistry ->
                 authorizationManagerRequestMatcherRegistry.anyRequest().authenticated());
 
-    return http.build();
+    return new OrderedSecurityFilterChain(config.getOrder(), http.build());
   }
 
   /**

--- a/sip-security/src/main/java/one/x1f/sip/foundation/security/config/SecurityConfigProperties.java
+++ b/sip-security/src/main/java/one/x1f/sip/foundation/security/config/SecurityConfigProperties.java
@@ -32,6 +32,10 @@ import org.springframework.util.PathMatcher;
 @AllArgsConstructor
 public class SecurityConfigProperties {
 
+  private String[] matcherPatterns = {"/**"};
+
+  private int order = 1;
+
   /** endpoints that should be left out of the complete authentication checks */
   private List<String> ignoredEndpoints = Collections.emptyList();
 

--- a/sip-security/src/test/java/one/x1f/sip/foundation/security/config/OrderedSecurityFilterChainTest.java
+++ b/sip-security/src/test/java/one/x1f/sip/foundation/security/config/OrderedSecurityFilterChainTest.java
@@ -1,0 +1,43 @@
+package one.x1f.sip.foundation.security.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.web.SecurityFilterChain;
+
+class OrderedSecurityFilterChainTest {
+
+  @Test
+  void When_CallDelegatedMethod_Expect_SourceMethodsCalled() {
+    // arrange
+    SecurityFilterChain delegate =
+        new SecurityFilterChain() {
+
+          @Override
+          public boolean matches(HttpServletRequest request) {
+            request.setAttribute("matchesCalled", true);
+            return true;
+          }
+
+          @Override
+          public List<Filter> getFilters() {
+            return List.of();
+          }
+        };
+    int order = 42;
+    OrderedSecurityFilterChain subject = new OrderedSecurityFilterChain(order, delegate);
+
+    // act + assert
+    assertThat(subject.getOrder()).isEqualTo(order);
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    assertThat(subject.matches(request)).isTrue();
+    assertThat(request.getAttribute("matchesCalled")).isEqualTo(true);
+
+    assertThat(subject.getFilters()).isEmpty();
+  }
+}


### PR DESCRIPTION
# Description

Remove default SecurityFilterChain with no matchers and make it more flexible and better compatible with additional SecurityFilterChain, Spring Security no longer allows multiple SecurityFilterChain with no matchers.

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SIP Framework version(s):
* Other configuration:

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing (regression) unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
