### PR TITLE
Disable testkit beans in runtime

### DIFF
--- a/changelogs/feature/disable-testkin-in-runtime.json
+++ b/changelogs/feature/disable-testkin-in-runtime.json
@@ -1,0 +1,5 @@
+{
+  "author": "Nemikor",
+  "pullrequestId": "313",
+  "message": "Prevent loading TestKit beans in runtime"
+}

--- a/sip-test-kit/src/main/java/one/x1f/sip/foundation/testkit/OnTestOrRuntimeEnabledCondition.java
+++ b/sip-test-kit/src/main/java/one/x1f/sip/foundation/testkit/OnTestOrRuntimeEnabledCondition.java
@@ -20,7 +20,7 @@ public class OnTestOrRuntimeEnabledCondition extends SpringBootCondition {
     }
 
     boolean isEnabled =
-        context.getEnvironment().getProperty("runtime.enabled", Boolean.class, false);
+        context.getEnvironment().getProperty("sip.testkit.enabled", Boolean.class, false);
     if (ClassUtils.isPresent(CLOUD_TESTKIT_AUTOCONFIGURATION_CLASS, context.getClassLoader())
         && isEnabled) {
 

--- a/sip-test-kit/src/main/java/one/x1f/sip/foundation/testkit/OnTestOrRuntimeEnabledCondition.java
+++ b/sip-test-kit/src/main/java/one/x1f/sip/foundation/testkit/OnTestOrRuntimeEnabledCondition.java
@@ -1,0 +1,32 @@
+package one.x1f.sip.foundation.testkit;
+
+import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.util.ClassUtils;
+
+public class OnTestOrRuntimeEnabledCondition extends SpringBootCondition {
+  private static final String CLOUD_TESTKIT_AUTOCONFIGURATION_CLASS =
+      "one.x1f.sip.cloud.testkit.SIPCloudTestKitAutoConfiguration";
+
+  @Override
+  public ConditionOutcome getMatchOutcome(
+      ConditionContext context, AnnotatedTypeMetadata metadata) {
+    List<String> activeProfiles = List.of(context.getEnvironment().getActiveProfiles());
+    if (activeProfiles.contains("test")) {
+      return ConditionOutcome.match("Active profile is 'test'");
+    }
+
+    boolean isEnabled =
+        context.getEnvironment().getProperty("runtime.enabled", Boolean.class, false);
+    if (ClassUtils.isPresent(CLOUD_TESTKIT_AUTOCONFIGURATION_CLASS, context.getClassLoader())
+        && isEnabled) {
+
+      return ConditionOutcome.match("Runtime tests are enabled");
+    }
+
+    return ConditionOutcome.noMatch("Neither 'test' profile is found nor runtime test is enabled ");
+  }
+}

--- a/sip-test-kit/src/main/java/one/x1f/sip/foundation/testkit/SIPTestKitAutoConfiguration.java
+++ b/sip-test-kit/src/main/java/one/x1f/sip/foundation/testkit/SIPTestKitAutoConfiguration.java
@@ -2,11 +2,13 @@ package one.x1f.sip.foundation.testkit;
 
 import one.x1f.sip.foundation.core.util.YamlPropertSourceFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 
 @Import(TestKitConfig.class)
 @AutoConfiguration
+@Conditional(OnTestOrRuntimeEnabledCondition.class)
 @PropertySource(
     value = "classpath:sip-testkit-default-config.yaml",
     factory = YamlPropertSourceFactory.class)

--- a/sip-test-kit/src/test/java/one/x1f/sip/cloud/testkit/SIPCloudTestKitAutoConfiguration.java
+++ b/sip-test-kit/src/test/java/one/x1f/sip/cloud/testkit/SIPCloudTestKitAutoConfiguration.java
@@ -1,0 +1,3 @@
+package one.x1f.sip.cloud.testkit;
+
+public class SIPCloudTestKitAutoConfiguration {}

--- a/sip-test-kit/src/test/java/one/x1f/sip/foundation/testkit/OnTestOrRuntimeEnabledConditionTest.java
+++ b/sip-test-kit/src/test/java/one/x1f/sip/foundation/testkit/OnTestOrRuntimeEnabledConditionTest.java
@@ -1,0 +1,54 @@
+package one.x1f.sip.foundation.testkit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.env.Environment;
+
+class OnTestOrRuntimeEnabledConditionTest {
+
+  @Test
+  void When_getMatchOutcome_With_TestProfile_Then_OutcomeIsMatch() {
+    OnTestOrRuntimeEnabledCondition subject = new OnTestOrRuntimeEnabledCondition();
+    ConditionContext context = mock(ConditionContext.class);
+    Environment environment = mock(Environment.class);
+    when(context.getEnvironment()).thenReturn(environment);
+    String[] profiles = {"test"};
+    when(environment.getActiveProfiles()).thenReturn(profiles);
+    ConditionOutcome target = subject.getMatchOutcome(context, null);
+
+    assertThat(target.isMatch()).isTrue();
+  }
+
+  @Test
+  void When_getMatchOutcome_With_RuntimeEnabledAndCloud_Then_OutcomeIsMatch() {
+    OnTestOrRuntimeEnabledCondition subject = new OnTestOrRuntimeEnabledCondition();
+    ConditionContext context = mock(ConditionContext.class);
+    Environment environment = mock(Environment.class);
+    when(context.getEnvironment()).thenReturn(environment);
+    when(environment.getActiveProfiles()).thenReturn(new String[] {});
+    when(environment.getProperty(anyString(), eq(Boolean.class), eq(false))).thenReturn(true);
+    ConditionOutcome target = subject.getMatchOutcome(context, null);
+
+    assertThat(target.isMatch()).isTrue();
+  }
+
+  @Test
+  void When_getMatchOutcome_With_RuntimeDisabled_Then_OutcomeIsNotMatch() {
+    OnTestOrRuntimeEnabledCondition subject = new OnTestOrRuntimeEnabledCondition();
+    ConditionContext context = mock(ConditionContext.class);
+    Environment environment = mock(Environment.class);
+    when(context.getEnvironment()).thenReturn(environment);
+    when(environment.getActiveProfiles()).thenReturn(new String[] {});
+    when(environment.getProperty(anyString(), eq(Boolean.class), eq(false))).thenReturn(false);
+    ConditionOutcome target = subject.getMatchOutcome(context, null);
+
+    assertThat(target.isMatch()).isFalse();
+  }
+}


### PR DESCRIPTION
# Description

Reduce the amount of spring beans loaded from the SIP Framework in Runtime by loading TestKit only for tests

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SIP Framework version(s):
* Other configuration:

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing (regression) unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
