### PR TITLE
Add useSipSecurity property to archetype

### DIFF
--- a/changelogs/feature/add-sip-security-in-archetype.json
+++ b/changelogs/feature/add-sip-security-in-archetype.json
@@ -1,0 +1,5 @@
+{
+  "author": "Nemikor",
+  "pullrequestId": "314",
+  "message": "Add useSipSecurity property to SIP Archetype which will include sip-security dependency in the generated adapter."
+}

--- a/docs-snapshot/archetype.md
+++ b/docs-snapshot/archetype.md
@@ -46,6 +46,7 @@ After executing given Maven command, you will be requested to insert additional 
 - **package** (optional) is used to override previous package naming and provide full package name. This can be skipped by leaving value empty.
   It is strongly recommended to follow package naming convention, otherwise your project will be created but it will have
   package naming errors.
+- **useSipSecurity** should be set to 'y' or 'Y' to include _SIP Security_ dependency in adapter.
 - **createDemoAdapter** should be set to 'y' or 'Y' when the inclusion of a demo adapter is desired.
     It will generate example classes using declarative structure, including process and scenario orchestration.
 - **useSipCloudFramework** should be set to 'y' or 'Y' to enable the premium version of the SIP framework. 
@@ -58,7 +59,7 @@ After executing given Maven command, you will be requested to insert additional 
 _Note_: All the parameters can be provided via command line if needed:
 
 ```shell
-mvn archetype:generate -DarchetypeGroupId=one.x1f.sip.foundation -DarchetypeArtifactId=sip-archetype -DarchetypeVersion=<latest.sip-framework.version> -DgroupId=one.x1f.sip.adapter -DartifactId=demo -DprojectName=DemoAdapter -Dversion=1.0.0-SNAPSHOT -DconnectorGroup1=group1 -DconnectorGroup2=group2 -DpackageSuffix=project -DuseLombok=y -DuseSoap=n -Dpackage=one.x1f.sip.adapter.demo.project -DcreateDemoAdapter=n -DuseSipCloudFramework=n -DuseJibPlugin=n
+mvn archetype:generate -DarchetypeGroupId=one.x1f.sip.foundation -DarchetypeArtifactId=sip-archetype -DarchetypeVersion=<latest.sip-framework.version> -DgroupId=one.x1f.sip.adapter -DartifactId=demo -DprojectName=DemoAdapter -Dversion=1.0.0-SNAPSHOT -DconnectorGroup1=group1 -DconnectorGroup2=group2 -DpackageSuffix=project -DuseLombok=y -DuseSoap=n -Dpackage=one.x1f.sip.adapter.demo.project -DuseSipSecurity=y -DcreateDemoAdapter=n -DuseSipCloudFramework=n -DuseJibPlugin=n
 ```
 
 After a successful build, a project with the following structure will be created:

--- a/sip-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/sip-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -64,6 +64,12 @@ under the License.
             <defaultValue>${useSoapDefault}</defaultValue>
         </requiredProperty>
         <requiredProperty key="archetypeVersion"> </requiredProperty>
+        <requiredProperty key="useSipSecurityDefault">
+            <defaultValue>y</defaultValue>
+        </requiredProperty>
+        <requiredProperty key="useSipSecurity">
+            <defaultValue>${useSipSecurityDefault}</defaultValue>
+        </requiredProperty>
         <requiredProperty key="createDemoAdapterDefault">
             <defaultValue>n</defaultValue>
         </requiredProperty>

--- a/sip-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/sip-archetype/src/main/resources/archetype-resources/pom.xml
@@ -44,6 +44,12 @@
             <artifactId>sip-integration-starter</artifactId>
         </dependency>
 #end
+#if (${useSipSecurity} == "y" or ${useSipSecurity} == "Y")
+        <dependency>
+            <groupId>one.x1f.sip.foundation</groupId>
+            <artifactId>sip-security</artifactId>
+        </dependency>
+#end
 #if (${useSoap} == "y" or ${useSoap} == "Y")
         <dependency>
             <groupId>one.x1f.sip.foundation</groupId>


### PR DESCRIPTION
# Description

Add useSipSecurity property to SIP Archetype which will include sip-security dependency in the generated adapter

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SIP Framework version(s):
* Other configuration:

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing (regression) unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
