### PR TITLE
Handle parent classes in declarative-structure-check

### DIFF
--- a/changelogs/bugfix/fix-declarative-structure-check-plugin.json
+++ b/changelogs/bugfix/fix-declarative-structure-check-plugin.json
@@ -1,0 +1,5 @@
+{
+  "author": "Nemikor",
+  "pullrequestId": "318",
+  "message": "Prevent compilation failure and instead print a warning in declarative-structure-check when there is class without matching annotation."
+}

--- a/sip-maven-plugin/src/main/java/one/x1f/sip/foundation/mvnplugin/DeclarativeClassAnalyser.java
+++ b/sip-maven-plugin/src/main/java/one/x1f/sip/foundation/mvnplugin/DeclarativeClassAnalyser.java
@@ -13,6 +13,7 @@ import one.x1f.sip.foundation.mvnplugin.model.ClassAnalysisOutcome;
 import one.x1f.sip.foundation.mvnplugin.model.ClassAnalysisResult;
 
 public class DeclarativeClassAnalyser {
+  private String projectGroupId;
 
   private final Map<String, String> expectedParentInterfaces =
       Map.of(
@@ -54,7 +55,7 @@ public class DeclarativeClassAnalyser {
     try {
       String name = current.getQualifiedName();
 
-      if (!name.startsWith(X1F_SIP_GROUP)) return;
+      if (!name.startsWith(X1F_SIP_GROUP) && !name.startsWith(projectGroupId)) return;
 
       ancestors.add(current);
       current
@@ -136,5 +137,9 @@ public class DeclarativeClassAnalyser {
     return annotations.stream()
         .anyMatch(
             annotationName -> annotationName.equals(expectedAnnotationClasses.get(interfaceName)));
+  }
+
+  public void setProjectGroupId(String projectGroupId) {
+    this.projectGroupId = projectGroupId;
   }
 }

--- a/sip-maven-plugin/src/main/java/one/x1f/sip/foundation/mvnplugin/DeclarativeClassAnalyser.java
+++ b/sip-maven-plugin/src/main/java/one/x1f/sip/foundation/mvnplugin/DeclarativeClassAnalyser.java
@@ -9,6 +9,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithName;
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import java.util.*;
+import one.x1f.sip.foundation.mvnplugin.model.ClassAnalysisOutcome;
 import one.x1f.sip.foundation.mvnplugin.model.ClassAnalysisResult;
 
 public class DeclarativeClassAnalyser {
@@ -45,7 +46,7 @@ public class DeclarativeClassAnalyser {
     List<ResolvedReferenceType> ancestors = new ArrayList<>();
     resolved.getAncestors().forEach(ancestor -> addResolvableAncestor(ancestor, ancestors));
 
-    return analyseDeclarativeStructure(resolved, annotations, ancestors);
+    return analyseDeclarativeStructure(clazz, resolved, annotations, ancestors);
   }
 
   private void addResolvableAncestor(
@@ -69,19 +70,21 @@ public class DeclarativeClassAnalyser {
   }
 
   private ClassAnalysisResult analyseDeclarativeStructure(
+      ClassOrInterfaceDeclaration clazz,
       ResolvedReferenceTypeDeclaration resolved,
       NodeList<AnnotationExpr> annotations,
       List<ResolvedReferenceType> ancestors) {
     List<String> annotationNames = annotations.stream().map(NodeWithName::getNameAsString).toList();
     ClassAnalysisResult result = analyseAnnotations(resolved, ancestors, annotationNames);
     if (result != null) return result;
-    result = analyseAncestors(resolved, ancestors, annotationNames);
+    result = analyseAncestors(clazz, resolved, ancestors, annotationNames);
     if (result != null) return result;
 
-    return new ClassAnalysisResult(false, resolved.getQualifiedName());
+    return new ClassAnalysisResult(ClassAnalysisOutcome.SUCCESS, resolved.getQualifiedName());
   }
 
   private ClassAnalysisResult analyseAncestors(
+      ClassOrInterfaceDeclaration clazz,
       ResolvedReferenceTypeDeclaration resolved,
       List<ResolvedReferenceType> ancestors,
       List<String> annotationNames) {
@@ -92,13 +95,13 @@ public class DeclarativeClassAnalyser {
             .filter(
                 ancestor -> !doesImplementedClassHaveMatchingAnnotation(annotationNames, ancestor))
             .toList();
-    if (!invalidAncestorMatches.isEmpty()) {
+    if (!invalidAncestorMatches.isEmpty() && !clazz.isAbstract()) {
       String ancestorName = invalidAncestorMatches.get(0);
       String second =
           String.format(
-              "Class %s must be annotated with @%s to match the required base class.",
+              "Class %s might need to be annotated with @%s to match the required base class or made abstract.",
               resolved.getQualifiedName(), expectedAnnotationClasses.get(ancestorName));
-      return new ClassAnalysisResult(true, second);
+      return new ClassAnalysisResult(ClassAnalysisOutcome.WARNING, second);
     }
     return null;
   }
@@ -116,7 +119,7 @@ public class DeclarativeClassAnalyser {
             String.format(
                 "Class %s annotated with @%s does not extend the required base type.",
                 resolved.getQualifiedName(), annotationName);
-        return new ClassAnalysisResult(true, message);
+        return new ClassAnalysisResult(ClassAnalysisOutcome.ERROR, message);
       }
     }
     return null;

--- a/sip-maven-plugin/src/main/java/one/x1f/sip/foundation/mvnplugin/DeclarativeStructureCheckMojo.java
+++ b/sip-maven-plugin/src/main/java/one/x1f/sip/foundation/mvnplugin/DeclarativeStructureCheckMojo.java
@@ -11,6 +11,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Stream;
+import one.x1f.sip.foundation.mvnplugin.model.ClassAnalysisOutcome;
 import one.x1f.sip.foundation.mvnplugin.model.ClassAnalysisResult;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
@@ -80,28 +81,31 @@ public class DeclarativeStructureCheckMojo extends AbstractMojo {
     try {
       Optional<CompilationUnit> result = parser.parse(path).getResult();
       if (result.isEmpty()) {
-        return new ClassAnalysisResult(false, null);
+        return new ClassAnalysisResult(ClassAnalysisOutcome.SUCCESS, null);
       }
       for (ClassOrInterfaceDeclaration clazz :
           result.get().findAll(ClassOrInterfaceDeclaration.class)) {
         var classAnalysisResult = declarativeClassAnalyser.doAnalysis(clazz);
-        if (classAnalysisResult.error()) {
+        if (classAnalysisResult.outcome().equals(ClassAnalysisOutcome.ERROR)
+            || classAnalysisResult.outcome().equals(ClassAnalysisOutcome.WARNING)) {
           return classAnalysisResult;
         }
       }
     } catch (Exception e) {
       getLog().warn("Failed to parse " + path + ": " + e.getMessage());
     }
-    return new ClassAnalysisResult(false, null);
+    return new ClassAnalysisResult(ClassAnalysisOutcome.SUCCESS, null);
   }
 
   private void validate(List<ClassAnalysisResult> analyseResult) throws MojoExecutionException {
     boolean hasErrors = false;
 
     for (ClassAnalysisResult res : analyseResult) {
-      if (res.error()) {
+      if (res.outcome().equals(ClassAnalysisOutcome.ERROR)) {
         getLog().error(res.message());
         hasErrors = true;
+      } else if (res.outcome().equals(ClassAnalysisOutcome.WARNING)) {
+        getLog().warn(res.message());
       }
     }
 

--- a/sip-maven-plugin/src/main/java/one/x1f/sip/foundation/mvnplugin/DeclarativeStructureCheckMojo.java
+++ b/sip-maven-plugin/src/main/java/one/x1f/sip/foundation/mvnplugin/DeclarativeStructureCheckMojo.java
@@ -43,6 +43,7 @@ public class DeclarativeStructureCheckMojo extends AbstractMojo {
 
   @Override
   public void execute() throws MojoExecutionException {
+    declarativeClassAnalyser.setProjectGroupId(mavenProject.getGroupId());
     try {
       CombinedTypeSolver typeSolver = new CombinedTypeSolver();
       typeSolver.add(new ReflectionTypeSolver());

--- a/sip-maven-plugin/src/main/java/one/x1f/sip/foundation/mvnplugin/model/ClassAnalysisOutcome.java
+++ b/sip-maven-plugin/src/main/java/one/x1f/sip/foundation/mvnplugin/model/ClassAnalysisOutcome.java
@@ -1,0 +1,7 @@
+package one.x1f.sip.foundation.mvnplugin.model;
+
+public enum ClassAnalysisOutcome {
+  SUCCESS,
+  ERROR,
+  WARNING
+}

--- a/sip-maven-plugin/src/main/java/one/x1f/sip/foundation/mvnplugin/model/ClassAnalysisResult.java
+++ b/sip-maven-plugin/src/main/java/one/x1f/sip/foundation/mvnplugin/model/ClassAnalysisResult.java
@@ -1,3 +1,3 @@
 package one.x1f.sip.foundation.mvnplugin.model;
 
-public record ClassAnalysisResult(boolean error, String message) {}
+public record ClassAnalysisResult(ClassAnalysisOutcome outcome, String message) {}

--- a/sip-maven-plugin/src/test/java/one/x1f/sip/foundation/connectors/con1/NoAnnotationAbstractConnector.java
+++ b/sip-maven-plugin/src/test/java/one/x1f/sip/foundation/connectors/con1/NoAnnotationAbstractConnector.java
@@ -1,0 +1,62 @@
+package one.x1f.sip.foundation.connectors.con1;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+import one.x1f.sip.foundation.core.declarative.connector.OutboundConnectorDefinition;
+import one.x1f.sip.foundation.core.declarative.orchestration.Orchestrator;
+import one.x1f.sip.foundation.core.declarative.orchestration.connector.ConnectorOrchestrationInfo;
+import org.apache.camel.model.RouteDefinition;
+
+public abstract class NoAnnotationAbstractConnector implements OutboundConnectorDefinition {
+
+  @Override
+  public void defineOutboundEndpoints(RouteDefinition routeDefinition) {
+    // test
+  }
+
+  @Override
+  public String getConnectorGroupId() {
+    return "";
+  }
+
+  @Override
+  public String getScenarioId() {
+    return "";
+  }
+
+  @Override
+  public Class<?> getRequestModelClass() {
+    return null;
+  }
+
+  @Override
+  public Optional<Class<?>> getResponseModelClass() {
+    return Optional.empty();
+  }
+
+  @Override
+  public String[] getConfigurationIds() {
+    return new String[0];
+  }
+
+  @Override
+  public List<Method> getOnExceptionHandler() {
+    return List.of();
+  }
+
+  @Override
+  public String getId() {
+    return "";
+  }
+
+  @Override
+  public String getPathToDocumentationResource() {
+    return "";
+  }
+
+  @Override
+  public Orchestrator<ConnectorOrchestrationInfo> getOrchestrator() {
+    return null;
+  }
+}

--- a/sip-maven-plugin/src/test/java/one/x1f/sip/foundation/connectors/con1/ValidConnectorFromAbstractParent.java
+++ b/sip-maven-plugin/src/test/java/one/x1f/sip/foundation/connectors/con1/ValidConnectorFromAbstractParent.java
@@ -1,0 +1,9 @@
+package one.x1f.sip.foundation.connectors.con1;
+
+import one.x1f.sip.foundation.core.declarative.annotation.OutboundConnector;
+
+@OutboundConnector(
+    connectorGroup = "test",
+    integrationScenario = "test",
+    requestModel = Object.class)
+public class ValidConnectorFromAbstractParent extends NoAnnotationAbstractConnector {}

--- a/sip-maven-plugin/src/test/java/one/x1f/sip/foundation/mvnplugin/DeclarativeStructureCheckMojoTest.java
+++ b/sip-maven-plugin/src/test/java/one/x1f/sip/foundation/mvnplugin/DeclarativeStructureCheckMojoTest.java
@@ -45,14 +45,15 @@ class DeclarativeStructureCheckMojoTest {
     MojoExecutionException ex = assertThrows(MojoExecutionException.class, subject::execute);
     assertEquals("Error analysing declarative structure.", ex.getMessage());
 
-    verify(log, times(2)).error(anyString());
+    verify(log, times(1)).error(anyString());
+    verify(log, times(1)).warn(anyString());
     verify(log)
         .error(
             contains(
                 "Class one.x1f.sip.foundation.connectors.con1.NoParentConnector annotated with @InboundConnector does not extend the required base type."));
     verify(log)
-        .error(
+        .warn(
             contains(
-                "Class one.x1f.sip.foundation.connectors.con1.NoAnnotationConnector must be annotated with @OutboundConnector to match the required base class."));
+                "Class one.x1f.sip.foundation.connectors.con1.NoAnnotationConnector might need to be annotated with @OutboundConnector to match the required base class or made abstract."));
   }
 }


### PR DESCRIPTION
# Description

Update declarative-structure-check from SIP Maven Plugin so that the compilation doesn't fail if there is a parent class without annotation, which may have child classes with correct annotation. Instead print a warning message.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SIP Framework version(s):
* Other configuration:

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing (regression) unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
